### PR TITLE
docker:支持在docker-compose文件中使用环境变量配置JVM内存参数

### DIFF
--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Docker-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Docker-Deployment_apache.md
@@ -196,6 +196,16 @@ docker cp iotdb:/iotdb/conf /docker-iotdb/iotdb/conf
 ```bash
 docker-compose  -f docker-compose-standalone.yml  up  -d
 ```
+### 2.7 使用环境变量配置内存
+功能：在docker-compose的配置文件中配置JVM启动内存。
+IoTDB版本大于等于2.0.4.1 或者大于等于1.3.5 以后才支持这种做法。
+```bash
+    environment:
+      # for datanode
+      - IOTDB_JMX_OPTS=-Xms4G -Xmx4G -XX:MaxDirectMemorySize=1G
+      # for confignode
+      - CONFIGNODE_JMX_OPTS=-Xms1G -Xmx1G -XX:MaxDirectMemorySize=256M
+```
 
 ## 3. 集群版
 

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Docker-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Docker-Deployment_timecho.md
@@ -238,6 +238,16 @@ docker cp iotdb:/iotdb/conf /docker-iotdb/iotdb/conf
 ```Bash
 docker-compose  -f docker-compose-standalone.yml  up  -d
 ```
+### 2.9 使用环境变量配置内存
+功能：在docker-compose的配置文件中配置JVM启动内存。
+IoTDB版本大于等于2.0.4.1 或者大于等于1.3.5 以后才支持这种做法。
+```bash
+    environment:
+      # for datanode
+      - IOTDB_JMX_OPTS=-Xms4G -Xmx4G -XX:MaxDirectMemorySize=1G
+      # for confignode
+      - CONFIGNODE_JMX_OPTS=-Xms1G -Xmx1G -XX:MaxDirectMemorySize=256M
+```
 
 ## 3. 集群版部署
 


### PR DESCRIPTION
docker:支持在docker-compose文件中使用环境变量配置JVM内存参数
supporting: configure JVM memory with environment variables in docker compose file
iotdb source codes link:
https://github.com/apache/iotdb/pull/15413