### PR TITLE
fix zeppelin links

### DIFF
--- a/src/.vuepress/sidebar/V2.0.x/zh-Tree.ts
+++ b/src/.vuepress/sidebar/V2.0.x/zh-Tree.ts
@@ -209,7 +209,7 @@ export const zhSidebar = {
           text: '可视化分析',
           collapsible: true,
           children: [
-            { text: 'Apache Zeppelin', link: 'Zeppelin-IoTDB' },
+            { text: 'Apache Zeppelin', link: 'Zeppelin-IoTDB_apache' },
             { text: 'Grafana', link: 'Grafana-Connector' },
             { text: 'Grafana插件', link: 'Grafana-Plugin' },
             { text: 'DataEase', link: 'DataEase' },

--- a/src/.vuepress/sidebar_timecho/V2.0.x/zh-Tree.ts
+++ b/src/.vuepress/sidebar_timecho/V2.0.x/zh-Tree.ts
@@ -220,7 +220,7 @@ export const zhSidebar = {
           text: '可视化分析',
           collapsible: true,
           children: [
-            { text: 'Apache Zeppelin', link: 'Zeppelin-IoTDB' },
+            { text: 'Apache Zeppelin', link: 'Zeppelin-IoTDB_timecho' },
             { text: 'Grafana', link: 'Grafana-Connector' },
             { text: 'Grafana插件', link: 'Grafana-Plugin' },
             { text: 'DataEase', link: 'DataEase' },


### PR DESCRIPTION
sidebar zh: 
{ text: 'Apache Zeppelin', link: 'Zeppelin-IoTDB_timecho' },
{ text: 'Apache Zeppelin', link: 'Zeppelin-IoTDB_apache' },