### PR TITLE
query timeout default value is 60s

### DIFF
--- a/src/UserGuide/Master/Tree/API/Programming-Java-Native-API.md
+++ b/src/UserGuide/Master/Tree/API/Programming-Java-Native-API.md
@@ -457,7 +457,7 @@ The Session class has the following fields, which can be set through the constru
 | **Method Name**                                              | **Function Description**                                 | **Parameter Explanation**                                    |
 | ------------------------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | Execute a query statement                                | `sql`: The query SQL statement                               |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds) |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds), default to the server configuration, which is 60s. |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | Query raw data for specified paths                       | paths: A list of query paths, `startTime`: The start timestamp, `endTime`: The end timestamp |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | Query raw data for specified paths (with timeout)        | Same as above, plus `timeOut`: The timeout time              |
 | `executeLastDataQuery(List<String> paths)`                   | Query the latest data                                    | `paths`: A list of query paths                               |

--- a/src/UserGuide/V1.3.x/API/Programming-Java-Native-API.md
+++ b/src/UserGuide/V1.3.x/API/Programming-Java-Native-API.md
@@ -457,7 +457,7 @@ The Session class has the following fields, which can be set through the constru
 | **Method Name**                                              | **Function Description**                                 | **Parameter Explanation**                                    |
 | ------------------------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | Execute a query statement                                | `sql`: The query SQL statement                               |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds) |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds), default to the server configuration, which is 60s. |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | Query raw data for specified paths                       | paths: A list of query paths, `startTime`: The start timestamp, `endTime`: The end timestamp |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | Query raw data for specified paths (with timeout)        | Same as above, plus `timeOut`: The timeout time              |
 | `executeLastDataQuery(List<String> paths)`                   | Query the latest data                                    | `paths`: A list of query paths                               |

--- a/src/UserGuide/dev-1.3/API/Programming-Java-Native-API.md
+++ b/src/UserGuide/dev-1.3/API/Programming-Java-Native-API.md
@@ -457,7 +457,7 @@ The Session class has the following fields, which can be set through the constru
 | **Method Name**                                              | **Function Description**                                 | **Parameter Explanation**                                    |
 | ------------------------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | Execute a query statement                                | `sql`: The query SQL statement                               |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds) |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds), default to the server configuration, which is 60s. |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | Query raw data for specified paths                       | paths: A list of query paths, `startTime`: The start timestamp, `endTime`: The end timestamp |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | Query raw data for specified paths (with timeout)        | Same as above, plus `timeOut`: The timeout time              |
 | `executeLastDataQuery(List<String> paths)`                   | Query the latest data                                    | `paths`: A list of query paths                               |

--- a/src/UserGuide/latest/API/Programming-Java-Native-API.md
+++ b/src/UserGuide/latest/API/Programming-Java-Native-API.md
@@ -457,7 +457,7 @@ The Session class has the following fields, which can be set through the constru
 | **Method Name**                                              | **Function Description**                                 | **Parameter Explanation**                                    |
 | ------------------------------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | Execute a query statement                                | `sql`: The query SQL statement                               |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds) |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | Execute a query statement with timeout                   | `sql`: The query SQL statement, `timeoutInMs`: The query timeout (in milliseconds), default to the server configuration, which is 60s. |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | Query raw data for specified paths                       | paths: A list of query paths, `startTime`: The start timestamp, `endTime`: The end timestamp |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | Query raw data for specified paths (with timeout)        | Same as above, plus `timeOut`: The timeout time              |
 | `executeLastDataQuery(List<String> paths)`                   | Query the latest data                                    | `paths`: A list of query paths                               |

--- a/src/zh/UserGuide/Master/Tree/API/Programming-Java-Native-API.md
+++ b/src/zh/UserGuide/Master/Tree/API/Programming-Java-Native-API.md
@@ -455,7 +455,7 @@ Session具有如下的字段，可以通过构造函数或Session.Builder方式�
 | 方法名                                                       | 功能描述                         | 参数解释                                                     |
 | ------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | 执行查询语句                     | `sql`: 查询SQL语句                                           |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒）      |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒），默认取服务器配置即60s      |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | 查询指定路径的原始数据           | `paths`: 查询路径列表，`startTime`: 起始时间戳，`endTime`: 结束时间戳 |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | 查询指定路径的原始数据（带超时） | 同上，增加 `timeOut`: 超时时间                               |
 | `executeLastDataQuery(List<String> paths)`                   | 查询最新数据                     | `paths`: 查询路径列表                                        |

--- a/src/zh/UserGuide/V1.3.x/API/Programming-Java-Native-API.md
+++ b/src/zh/UserGuide/V1.3.x/API/Programming-Java-Native-API.md
@@ -455,7 +455,7 @@ Session具有如下的字段，可以通过构造函数或Session.Builder方式�
 | 方法名                                                       | 功能描述                         | 参数解释                                                     |
 | ------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | 执行查询语句                     | `sql`: 查询SQL语句                                           |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒）      |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒），默认取服务器配置即60s      |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | 查询指定路径的原始数据           | `paths`: 查询路径列表，`startTime`: 起始时间戳，`endTime`: 结束时间戳 |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | 查询指定路径的原始数据（带超时） | 同上，增加 `timeOut`: 超时时间                               |
 | `executeLastDataQuery(List<String> paths)`                   | 查询最新数据                     | `paths`: 查询路径列表                                        |

--- a/src/zh/UserGuide/dev-1.3/API/Programming-Java-Native-API.md
+++ b/src/zh/UserGuide/dev-1.3/API/Programming-Java-Native-API.md
@@ -455,7 +455,7 @@ Session具有如下的字段，可以通过构造函数或Session.Builder方式�
 | 方法名                                                       | 功能描述                         | 参数解释                                                     |
 | ------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | 执行查询语句                     | `sql`: 查询SQL语句                                           |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒）      |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒），默认取服务器配置即60s      |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | 查询指定路径的原始数据           | `paths`: 查询路径列表，`startTime`: 起始时间戳，`endTime`: 结束时间戳 |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | 查询指定路径的原始数据（带超时） | 同上，增加 `timeOut`: 超时时间                               |
 | `executeLastDataQuery(List<String> paths)`                   | 查询最新数据                     | `paths`: 查询路径列表                                        |

--- a/src/zh/UserGuide/latest/API/Programming-Java-Native-API.md
+++ b/src/zh/UserGuide/latest/API/Programming-Java-Native-API.md
@@ -455,7 +455,7 @@ Session具有如下的字段，可以通过构造函数或Session.Builder方式�
 | 方法名                                                       | 功能描述                         | 参数解释                                                     |
 | ------------------------------------------------------------ | -------------------------------- | ------------------------------------------------------------ |
 | `executeQueryStatement(String sql)`                          | 执行查询语句                     | `sql`: 查询SQL语句                                           |
-| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒）      |
+| `executeQueryStatement(String sql, long timeoutInMs)`        | 执行带超时的查询语句             | `sql`: 查询SQL语句，`timeoutInMs`: 查询超时时间（毫秒），默认取服务器配置即60s      |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime)` | 查询指定路径的原始数据           | `paths`: 查询路径列表，`startTime`: 起始时间戳，`endTime`: 结束时间戳 |
 | `executeRawDataQuery(List<String> paths, long startTime, long endTime, long timeOut)` | 查询指定路径的原始数据（带超时） | 同上，增加 `timeOut`: 超时时间                               |
 | `executeLastDataQuery(List<String> paths)`                   | 查询最新数据                     | `paths`: 查询路径列表                                        |


### PR DESCRIPTION
Timeout of query can be set by users. A negative number means using the default configuration of server（60s）.
1.3.x/dev-1.3/2.0.x/master tree:
Programming-JAVA-Native-API.md