### PR TITLE
add new params and note in scp datasync and tsfilebackup

### DIFF
--- a/src/UserGuide/Master/Table/Tools-System/Data-Export-Tool_timecho.md
+++ b/src/UserGuide/Master/Table/Tools-System/Data-Export-Tool_timecho.md
@@ -204,25 +204,27 @@ Since **V2.0.9.2**, IoTDB supports the `tsfile-backup.sh/bat` script. This scrip
 
 
 ### 3.2 Script Parameters
-| Abbreviation | Full Name          | Description                                                                                                 | Required | Default         |
-| ------------ | ------------------ | ----------------------------------------------------------------------------------------------------------- | -------- | --------------- |
-| `-sql_dialect` | `--sql_dialect`    | Specifies the data model type. Valid values: `tree` (Tree Model) or `table` (Table Model).                  | Yes      | -               |
-| `-h`         | `--host`           | Local host address (IP of the IoTDB instance where the data resides).                                        | No       | `127.0.0.1`     |
-| `-p`         | `--port`           | Port number for the IoTDB RPC service.                                                                      | No       | `6667`          |
-| `-u`         | `--user`           | Username for IoTDB authentication.                                                                         | No       | `root`          |
-| `-pw`        | `--password`       | Password for IoTDB authentication (hidden input supported).                                                 | No       | `root`          |
-| `-t`         | `--target`         | Export target directory. In SCP mode, this is an absolute physical path on the remote server. TsFile and associated Object directories will be exported here. | Yes | - |
-| `-db`        | `--database`       | Database name (optional for Table Model).                                                                   | No       | `.*`            |
-| `-table`     | `--table`          | Table name (optional for Table Model).                                                                      | No       | `.*`            |
-| `-s`         | `--start_time`     | Start time (ISO8601 format e.g. `2026-01-01T00:00:00` or millisecond timestamp). Only data from this time onwards is exported. | No | - |
-| `-e`         | `--end_time`       | End time (same format as above). Only data before this time is exported.                                    | No       | -               |
-| `-th`        | `--target_host`    | Remote target host IP. If specified, the script automatically configures Pipe to use SCP for data transfer. | No       | -               |
-| `-tu`        | `--target_host_user` | Username for SSH/SCP login to the remote server.                                                           | No       | -               |
-| `-tpw`       | `--target_host_pw` | Password for remote authentication (hidden input supported).                                                | No       | -               |
-| `-tp`        | `--target_host_port` | Remote SSH port.                                                                                           | No       | `22`            |
-| `--rate_limit` | `--rate_limit`     | Transfer rate limit (unit: Bytes/s) to prevent excessive bandwidth usage.                                   | No       | -               |
-| `--plugin_jar` | `--plugin_jar`     | Path to the Pipe plugin JAR file.                                                                           | No       | -               |
-| `-help`      | `--help`           | Show help information.                                                                                      | No       | -               |
+| Abbreviation            | Full Name                | Description                                                                                                                                                   | Required | Default         |
+|-------------------------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- | --------------- |
+| `-sql_dialect`          | `--sql_dialect`          | Specifies the data model type. Valid values: `tree` (Tree Model) or `table` (Table Model).                                                                    | Yes      | -               |
+| `-h`                    | `--host`                 | Local host address (IP of the IoTDB instance where the data resides).                                                                                         | No       | `127.0.0.1`     |
+| `-p`                    | `--port`                 | Port number for the IoTDB RPC service.                                                                                                                        | No       | `6667`          |
+| `-u`                    | `--user`                 | Username for IoTDB authentication.                                                                                                                            | No       | `root`          |
+| `-pw`                   | `--password`             | Password for IoTDB authentication (hidden input supported).                                                                                                   | No       | `root`          |
+| `-t`                    | `--target`               | Export target directory. In SCP mode, this is an absolute physical path on the remote server. TsFile and associated Object directories will be exported here. | Yes | - |
+| `-db`                   | `--database`             | Database name (optional for Table Model).                                                                                                                     | No       | `.*`            |
+| `-table`                | `--table`                | Table name (optional for Table Model).                                                                                                                        | No       | `.*`            |
+| `-s`                    | `--start_time`           | Start time (ISO8601 format e.g. `2026-01-01T00:00:00` or millisecond timestamp). Only data from this time onwards is exported.                                | No | - |
+| `-e`                    | `--end_time`             | End time (same format as above). Only data before this time is exported.                                                                                      | No       | -               |
+| `-th`                   | `--target_host`          | Remote target host IP. If specified, the script automatically configures Pipe to use SCP for data transfer.                                                   | No       | -               |
+| `-tu`                   | `--target_host_user`     | Username for SSH/SCP login to the remote server.                                                                                                              | No       | -               |
+| `-tpw`                  | `--target_host_pw`       | Password for remote authentication (hidden input supported).                                                                                                  | No       | -               |
+| `-tp`                   | `--target_host_port`     | Remote SSH port.                                                                                                                                              | No       | `22`            |
+| `--rate_limit`          | `--rate_limit`           | Transfer rate limit (unit: Bytes/s) to prevent excessive bandwidth usage.                                                                                     | No       | -               |
+| `--plugin_jar`          | `--plugin_jar`           | Path to the Pipe plugin JAR file.                                                                                                                             | No       | -               |
+| `--object-parallelism`  | `--object-parallelism`   | Specifies the maximum parallelism for object file transmission.                                                                                               | No       | -           |
+| `--object-batch-size`   | `--object-batch-size`    | Limits the total byte size of each object file upload batch, used to control memory usage and single SCP transfer size.                                       | No        | -           |
+| `-help`                 | `--help`                 | Show help information.                                                                                                                                        | No       | -               |
 
 
 ### 3.3 Execution Examples
@@ -244,3 +246,7 @@ Example 3: Specify Pipe Plugin JAR Directory
 ```Bash
 ./tsfile-backup.sh -sql_dialect table -db test -table .* -tu luoluoyuyu -tpw -t /tmp/backup --plugin_jar /local/lib/tsfile-remote-sink-2.0.8-SNAPSHOT-jar-with-dependencies.jar
 ```
+
+**Note**: When exporting Object-type data in SCP mode, to avoid handshake exceptions, connection failures, or frequent Pipe restarts, it is recommended to take any of the following measures:
+* Appropriately lower the configuration parameter `object-parallelism`
+* Increase the `MaxStartups` value on the target machine as needed. After modification, execute `sshd reload` or `sshd restart` for the configuration to take effect.

--- a/src/UserGuide/Master/Table/User-Manual/Data-Sync_timecho.md
+++ b/src/UserGuide/Master/Table/User-Manual/Data-Sync_timecho.md
@@ -608,6 +608,10 @@ WITH SINK (
 );
 ```
 
+**Note**: When exporting Object-type data in SCP mode, to avoid handshake exceptions, connection failures, or frequent Pipe restarts, it is recommended to take any of the following measures:
+* Appropriately lower the configuration parameter `sink.scp.object-parallelism`
+* Increase the `MaxStartups` value on the target machine as needed. After modification, execute `sshd reload` or `sshd restart` for the configuration to take effect.
+
 **Sink Exported TSFile and Object Format:**
 
 ```Bash
@@ -809,13 +813,15 @@ pipe_all_sinks_rate_limit_bytes_per_second=-1
 | sink.rate-limit-bytes-per-second  | Rate limit threshold (unit: bytes/second). Takes effect when enabled. No limit if rate-limit <= 0 | Long                   | No       | 0       |
 
 #### tsfile-remote-sink
-| Parameter                           | Description                                                                 | Value Range             | Required | Default |
-|------------------------------------|-----------------------------------------------------------------------------|-------------------------|----------|---------|
-| sink                               | Component name                                                              | String: tsfile-remote-sink | Yes      | -       |
-| sink.scp.host                      | Remote host IP                                                              | String                  | Yes      | -       |
-| sink.scp.port                      | Remote SSH port                                                             | Long                    | No       | 22      |
-| sink.scp.user                      | Remote SSH user                                                             | String                  | Yes      | -       |
-| sink.scp.password                  | Remote SSH password                                                         | String                  | Yes      | -       |
-| sink.scp.remote-path               | Remote target directory                                                      | String                  | Yes      | -       |
-| sink.rate-limit-bytes-per-second   | Unit: bytes/second. Takes effect when enabled. No limit if rate-limit <= 0  | Long                    | No       | 0       |
+| Parameter                           | Description                                                                | Value Range             | Required | Default |
+|------------------------------------|----------------------------------------------------------------------------|-------------------------|----------|---------|
+| sink                               | Component name                                                             | String: tsfile-remote-sink | Yes      | -       |
+| sink.scp.host                      | Remote host IP                                                             | String                  | Yes      | -       |
+| sink.scp.port                      | Remote SSH port                                                            | Long                    | No       | 22      |
+| sink.scp.user                      | Remote SSH user                                                            | String                  | Yes      | -       |
+| sink.scp.password                  | Remote SSH password                                                        | String                  | Yes      | -       |
+| sink.scp.remote-path               | Remote target directory                                                    | String                  | Yes      | -       |
+| sink.rate-limit-bytes-per-second   | Unit: bytes/second. Takes effect when enabled. No limit if rate-limit <= 0 | Long                    | No       | 0       |
+| sink.scp.object-parallelism       | Maximum parallelism for object file transmission                           | Long                       | No        |` min（cpu/4，16）` |
+| sink.scp.object-batch-size-bytes  | Maximum size of Object files sent per asynchronous thread, unit: MB        | Long                       | No        | 200          |
 

--- a/src/UserGuide/latest-Table/Tools-System/Data-Export-Tool_timecho.md
+++ b/src/UserGuide/latest-Table/Tools-System/Data-Export-Tool_timecho.md
@@ -204,25 +204,27 @@ Since **V2.0.9.2**, IoTDB supports the `tsfile-backup.sh/bat` script. This scrip
 
 
 ### 3.2 Script Parameters
-| Abbreviation | Full Name          | Description                                                                                                 | Required | Default         |
-| ------------ | ------------------ | ----------------------------------------------------------------------------------------------------------- | -------- | --------------- |
-| `-sql_dialect` | `--sql_dialect`    | Specifies the data model type. Valid values: `tree` (Tree Model) or `table` (Table Model).                  | Yes      | -               |
-| `-h`         | `--host`           | Local host address (IP of the IoTDB instance where the data resides).                                        | No       | `127.0.0.1`     |
-| `-p`         | `--port`           | Port number for the IoTDB RPC service.                                                                      | No       | `6667`          |
-| `-u`         | `--user`           | Username for IoTDB authentication.                                                                         | No       | `root`          |
-| `-pw`        | `--password`       | Password for IoTDB authentication (hidden input supported).                                                 | No       | `root`          |
-| `-t`         | `--target`         | Export target directory. In SCP mode, this is an absolute physical path on the remote server. TsFile and associated Object directories will be exported here. | Yes | - |
-| `-db`        | `--database`       | Database name (optional for Table Model).                                                                   | No       | `.*`            |
-| `-table`     | `--table`          | Table name (optional for Table Model).                                                                      | No       | `.*`            |
-| `-s`         | `--start_time`     | Start time (ISO8601 format e.g. `2026-01-01T00:00:00` or millisecond timestamp). Only data from this time onwards is exported. | No | - |
-| `-e`         | `--end_time`       | End time (same format as above). Only data before this time is exported.                                    | No       | -               |
-| `-th`        | `--target_host`    | Remote target host IP. If specified, the script automatically configures Pipe to use SCP for data transfer. | No       | -               |
-| `-tu`        | `--target_host_user` | Username for SSH/SCP login to the remote server.                                                           | No       | -               |
-| `-tpw`       | `--target_host_pw` | Password for remote authentication (hidden input supported).                                                | No       | -               |
-| `-tp`        | `--target_host_port` | Remote SSH port.                                                                                           | No       | `22`            |
-| `--rate_limit` | `--rate_limit`     | Transfer rate limit (unit: Bytes/s) to prevent excessive bandwidth usage.                                   | No       | -               |
-| `--plugin_jar` | `--plugin_jar`     | Path to the Pipe plugin JAR file.                                                                           | No       | -               |
-| `-help`      | `--help`           | Show help information.                                                                                      | No       | -               |
+| Abbreviation            | Full Name                | Description                                                                                                                                                   | Required | Default         |
+|-------------------------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------| -------- | --------------- |
+| `-sql_dialect`          | `--sql_dialect`          | Specifies the data model type. Valid values: `tree` (Tree Model) or `table` (Table Model).                                                                    | Yes      | -               |
+| `-h`                    | `--host`                 | Local host address (IP of the IoTDB instance where the data resides).                                                                                         | No       | `127.0.0.1`     |
+| `-p`                    | `--port`                 | Port number for the IoTDB RPC service.                                                                                                                        | No       | `6667`          |
+| `-u`                    | `--user`                 | Username for IoTDB authentication.                                                                                                                            | No       | `root`          |
+| `-pw`                   | `--password`             | Password for IoTDB authentication (hidden input supported).                                                                                                   | No       | `root`          |
+| `-t`                    | `--target`               | Export target directory. In SCP mode, this is an absolute physical path on the remote server. TsFile and associated Object directories will be exported here. | Yes | - |
+| `-db`                   | `--database`             | Database name (optional for Table Model).                                                                                                                     | No       | `.*`            |
+| `-table`                | `--table`                | Table name (optional for Table Model).                                                                                                                        | No       | `.*`            |
+| `-s`                    | `--start_time`           | Start time (ISO8601 format e.g. `2026-01-01T00:00:00` or millisecond timestamp). Only data from this time onwards is exported.                                | No | - |
+| `-e`                    | `--end_time`             | End time (same format as above). Only data before this time is exported.                                                                                      | No       | -               |
+| `-th`                   | `--target_host`          | Remote target host IP. If specified, the script automatically configures Pipe to use SCP for data transfer.                                                   | No       | -               |
+| `-tu`                   | `--target_host_user`     | Username for SSH/SCP login to the remote server.                                                                                                              | No       | -               |
+| `-tpw`                  | `--target_host_pw`       | Password for remote authentication (hidden input supported).                                                                                                  | No       | -               |
+| `-tp`                   | `--target_host_port`     | Remote SSH port.                                                                                                                                              | No       | `22`            |
+| `--rate_limit`          | `--rate_limit`           | Transfer rate limit (unit: Bytes/s) to prevent excessive bandwidth usage.                                                                                     | No       | -               |
+| `--plugin_jar`          | `--plugin_jar`           | Path to the Pipe plugin JAR file.                                                                                                                             | No       | -               |
+| `--object-parallelism`  | `--object-parallelism`   | Specifies the maximum parallelism for object file transmission.                                                                                               | No       | -           |
+| `--object-batch-size`   | `--object-batch-size`    | Limits the total byte size of each object file upload batch, used to control memory usage and single SCP transfer size.                                       | No        | -           |
+| `-help`                 | `--help`                 | Show help information.                                                                                                                                        | No       | -               |
 
 
 ### 3.3 Execution Examples
@@ -244,3 +246,7 @@ Example 3: Specify Pipe Plugin JAR Directory
 ```Bash
 ./tsfile-backup.sh -sql_dialect table -db test -table .* -tu luoluoyuyu -tpw -t /tmp/backup --plugin_jar /local/lib/tsfile-remote-sink-2.0.8-SNAPSHOT-jar-with-dependencies.jar
 ```
+
+**Note**: When exporting Object-type data in SCP mode, to avoid handshake exceptions, connection failures, or frequent Pipe restarts, it is recommended to take any of the following measures:
+* Appropriately lower the configuration parameter `object-parallelism`
+* Increase the `MaxStartups` value on the target machine as needed. After modification, execute `sshd reload` or `sshd restart` for the configuration to take effect.

--- a/src/UserGuide/latest-Table/User-Manual/Data-Sync_timecho.md
+++ b/src/UserGuide/latest-Table/User-Manual/Data-Sync_timecho.md
@@ -608,6 +608,10 @@ WITH SINK (
 );
 ```
 
+**Note**: When exporting Object-type data in SCP mode, to avoid handshake exceptions, connection failures, or frequent Pipe restarts, it is recommended to take any of the following measures:
+* Appropriately lower the configuration parameter `sink.scp.object-parallelism`
+* Increase the `MaxStartups` value on the target machine as needed. After modification, execute `sshd reload` or `sshd restart` for the configuration to take effect.
+
 **Sink Exported TSFile and Object Format:**
 
 ```Bash
@@ -809,13 +813,15 @@ pipe_all_sinks_rate_limit_bytes_per_second=-1
 | sink.rate-limit-bytes-per-second  | Rate limit threshold (unit: bytes/second). Takes effect when enabled. No limit if rate-limit <= 0 | Long                   | No       | 0       |
 
 #### tsfile-remote-sink
-| Parameter                           | Description                                                                 | Value Range             | Required | Default |
-|------------------------------------|-----------------------------------------------------------------------------|-------------------------|----------|---------|
-| sink                               | Component name                                                              | String: tsfile-remote-sink | Yes      | -       |
-| sink.scp.host                      | Remote host IP                                                              | String                  | Yes      | -       |
-| sink.scp.port                      | Remote SSH port                                                             | Long                    | No       | 22      |
-| sink.scp.user                      | Remote SSH user                                                             | String                  | Yes      | -       |
-| sink.scp.password                  | Remote SSH password                                                         | String                  | Yes      | -       |
-| sink.scp.remote-path               | Remote target directory                                                      | String                  | Yes      | -       |
-| sink.rate-limit-bytes-per-second   | Unit: bytes/second. Takes effect when enabled. No limit if rate-limit <= 0  | Long                    | No       | 0       |
+| Parameter                           | Description                                                                | Value Range             | Required | Default |
+|------------------------------------|----------------------------------------------------------------------------|-------------------------|----------|---------|
+| sink                               | Component name                                                             | String: tsfile-remote-sink | Yes      | -       |
+| sink.scp.host                      | Remote host IP                                                             | String                  | Yes      | -       |
+| sink.scp.port                      | Remote SSH port                                                            | Long                    | No       | 22      |
+| sink.scp.user                      | Remote SSH user                                                            | String                  | Yes      | -       |
+| sink.scp.password                  | Remote SSH password                                                        | String                  | Yes      | -       |
+| sink.scp.remote-path               | Remote target directory                                                    | String                  | Yes      | -       |
+| sink.rate-limit-bytes-per-second   | Unit: bytes/second. Takes effect when enabled. No limit if rate-limit <= 0 | Long                    | No       | 0       |
+| sink.scp.object-parallelism       | Maximum parallelism for object file transmission                           | Long                       | No        |` min（cpu/4，16）` |
+| sink.scp.object-batch-size-bytes  | Maximum size of Object files sent per asynchronous thread, unit: MB        | Long                       | No        | 200          |
 

--- a/src/zh/UserGuide/Master/Table/Tools-System/Data-Export-Tool_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Tools-System/Data-Export-Tool_timecho.md
@@ -213,25 +213,27 @@ IoTDB 自 **V2.0.9.2** 版本起支持 `tsfile-backup.sh/bat` 脚本，该脚本
 
 ### 3.2 脚本参数
 
-| 参数缩写           | 参数全称                 | 参数含义                                                                                                 | 是否为必填项 | 默认值             |
-| -------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------- | -------------------- |
-| `-sql_dialect` | `--sql_dialect`      | 指定数据模型类型，可选值：`tree`(树模型) 或`table`(表模型)。                                     | 是           | -                  |
-| `-h`           | `--host`             | 本地主机地址。指当前数据所在的 IoTDB 实例 IP。                                                           | 否           | `127.0.0.1`    |
-| `-p`           | `--port`             | 端口号，IoTDB RPC 服务端口。                                                                             | 否           | `6667`         |
-| `-u`           | `--user`             | 用户名，用于登录 IoTDB 验证。                                                                            | 否           | `root`         |
-| `-pw`          | `--password`         | 密码，对应用户的IoTDB密码，支持隐藏输入。                                                                | 否           | `root`         |
-| `-t`           | `--target`           | 导出目标目录。在 SCP 模式下，此路径指远程服务器上的绝对物理路径。TsFile 和关联的 Object 目录将导出至此。 | 是           | -                  |
-| `-db`          | `--database`         | 数据库名称 (表模型可选)                                                                                  | 否           | `.*`           |
-| `-table`       | `--table`            | 表名 (表模型可选)                                                                                        | 否           | `.*`           |
-| `-s`           | `--start_time`       | 起始时间。支持 ISO8601 格式（如 2026-01-01T00:00:00）或毫秒时间戳。仅导出该时间点及之后的数据。          | 否           | -                  |
-| `-e`           | `--end_time`         | 截止时间。格式同上。仅导出该时间点之前的数据。                                                           | 否           | -                  |
-| `-th`          | `--target_host`      | 远程目标主机 IP，默认自动识别启动脚本的IP。指定此参数后，脚本将自动配置 Pipe 使用 SCP 模式进行数据传输。 | 否           | -                  |
-| `-tu`          | `--target_host_user` | 远程主机用户名。用于 SSH/SCP 登录目标服务器。                                                            | 否           | -                  |
-| `-tpw`         | `--target_host_pw`   | 远程主机密码。用于远程身份验证，支持隐藏输入。                                                           | 否           | -                  |
-| `-tp`          | `--target_host_port` | 远程 SSH 端口。                                                                                          | 否           | `22`           |
-| `--rate_limit` | `--rate_limit`       | 发送速率限制。单位：字节/秒 (Bytes/s)。防止导出任务占用过多网络带宽。                                    | 否           | -                  |
-| `--plugin_jar` | `--plugin_jar`       | 指定 Pipe 插件的Jar包路径                                                                                | 否           | -                  |
-| `-help`        | `--help`             | 查看帮助                                                                                                 | 否           | -                  |
+| 参数缩写                   | 参数全称                   | 参数含义                                                           | 是否为必填项 | 默认值         |
+|------------------------|------------------------|----------------------------------------------------------------| -------------- |-------------|
+| `-sql_dialect`         | `--sql_dialect`        | 指定数据模型类型，可选值：`tree`(树模型) 或`table`(表模型)。                        | 是           | -           |
+| `-h`                   | `--host`               | 本地主机地址。指当前数据所在的 IoTDB 实例 IP。                                   | 否           | `127.0.0.1` |
+| `-p`                   | `--port`               | 端口号，IoTDB RPC 服务端口。                                            | 否           | `6667`      |
+| `-u`                   | `--user`               | 用户名，用于登录 IoTDB 验证。                                             | 否           | `root`      |
+| `-pw`                  | `--password`           | 密码，对应用户的IoTDB密码，支持隐藏输入。                                        | 否           | `root`      |
+| `-t`                   | `--target`             | 导出目标目录。在 SCP 模式下，此路径指远程服务器上的绝对物理路径。TsFile 和关联的 Object 目录将导出至此。 | 是           | -           |
+| `-db`                  | `--database`           | 数据库名称 (表模型可选)                                                  | 否           | `.*`        |
+| `-table`               | `--table`              | 表名 (表模型可选)                                                     | 否           | `.*`        |
+| `-s`                   | `--start_time`         | 起始时间。支持 ISO8601 格式（如 2026-01-01T00:00:00）或毫秒时间戳。仅导出该时间点及之后的数据。 | 否           | -           |
+| `-e`                   | `--end_time`           | 截止时间。格式同上。仅导出该时间点之前的数据。                                        | 否           | -           |
+| `-th`                  | `--target_host`        | 远程目标主机 IP，默认自动识别启动脚本的IP。指定此参数后，脚本将自动配置 Pipe 使用 SCP 模式进行数据传输。   | 否           | -           |
+| `-tu`                  | `--target_host_user`   | 远程主机用户名。用于 SSH/SCP 登录目标服务器。                                    | 否           | -           |
+| `-tpw`                 | `--target_host_pw`     | 远程主机密码。用于远程身份验证，支持隐藏输入。                                        | 否           | -           |
+| `-tp`                  | `--target_host_port`   | 远程 SSH 端口。                                                     | 否           | `22`        |
+| `--rate_limit`         | `--rate_limit`         | 发送速率限制。单位：字节/秒 (Bytes/s)。防止导出任务占用过多网络带宽。                       | 否           | -           |
+| `--plugin_jar`         | `--plugin_jar`         | 指定 Pipe 插件的Jar包路径                                              | 否           | -           |
+| `--object-parallelism` | `--object-parallelism` | 指定object文件发送最大并行度                                              | 否        | -           |
+| `--object-batch-size`  | `--object-batch-size`  | 限制每个对象文件上传批次的总字节数，用于控制内存占用和单次 SCP 传输大小                         | 否        | -           |
+| `-help`                | `--help`               | 查看帮助                                                           | 否           | -           |
 
 ### 3.3 运行示例
 
@@ -252,3 +254,7 @@ IoTDB 自 **V2.0.9.2** 版本起支持 `tsfile-backup.sh/bat` 脚本，该脚本
 ```Bash
 ./tsfile-backup.sh -sql_dialect table -db test  -table .* -tu luoluoyuyu -tpw  -t /tmp/backup --plugin_jar /local/lib/tsfile-remote-sink-2.0.8-SNAPSHOT-jar-with-dependencies.jar
 ```
+
+注意：SCP 模式导出 Object 类型数据时，为避免出现握手异常、连接失败或 Pipe 频繁启停问题，建议采取以下任一措施：
+* 适当调低配置参数 object-parallelism
+* 按需调大目标机的 MaxStartups，修改后执行 sshd reload 或 sshd restart 使配置生效

--- a/src/zh/UserGuide/Master/Table/User-Manual/Data-Sync_timecho.md
+++ b/src/zh/UserGuide/Master/Table/User-Manual/Data-Sync_timecho.md
@@ -602,6 +602,10 @@ WITH SINK (
 );
 ```
 
+注意：远程导出 Object 类型数据时，为避免出现握手异常、连接失败或 Pipe 频繁启停问题，建议采取以下任一措施：
+* 适当调低配置参数 sink.scp.object-parallelism
+* 按需调大目标机的 MaxStartups，修改后执行 sshd reload 或 sshd restart 使配置生效
+
 **Sink 导出 TSFile 与 Object 格式：**
 
 ```Bash
@@ -805,12 +809,14 @@ pipe_all_sinks_rate_limit_bytes_per_second=-1
 
 #### tsfile-remote-sink
 
-| **参数**                             | **描述**                            | **value 取值范围**           | **是否必填** | **默认值** |
-|------------------------------------|-----------------------------------|--------------------------|----------|---------|
-| sink                               | 组件名称                              | String: tsfile-remote-sink | 是        | -       |
-| sink.scp.host                      | 远程主机 IP                           | String                   | 是        | -       |
-| sink.scp.port                      | 远程 SSH 端口                         | Long                     | 否        | 22      |
-| sink.scp.user                      | 远程 SSH 用户                         | String                   | 是        | -       |
-| sink.scp.password                  | 远程 SSH 密码                         | String                   | 是        | -       |
-| sink.scp.remote-path               | 远程目标目录                            | String                   | 是        | -       |
-| sink.rate-limit-bytes-per-second   | 单位：字节/秒。开启限速时生效。rate-limit<=0不限速  | Long                     | 否        | 0       |
+| **参数**                            | **描述**                               | **value 取值范围**             | **是否必填** | **默认值**      |
+|-----------------------------------|--------------------------------------|----------------------------|----------|--------------|
+| sink                              | 组件名称                                 | String: tsfile-remote-sink | 是        | -            |
+| sink.scp.host                     | 远程主机 IP                              | String                     | 是        | -            |
+| sink.scp.port                     | 远程 SSH 端口                            | Long                       | 否        | 22           |
+| sink.scp.user                     | 远程 SSH 用户                            | String                     | 是        | -            |
+| sink.scp.password                 | 远程 SSH 密码                            | String                     | 是        | -            |
+| sink.scp.remote-path              | 远程目标目录                               | String                     | 是        | -            |
+| sink.rate-limit-bytes-per-second  | 单位：字节/秒。开启限速时生效。rate-limit<=0不限速     | Long                       | 否        | 0            |
+| sink.scp.object-parallelism       | object文件发送最大并行度                      | Long                       | 否        | `min（cpu/4，16）` |
+| sink.scp.object-batch-size-bytes  | 单次异步线程发送的最大Object文件大小, 单位 MB         | Long                       | 否        | 200          |

--- a/src/zh/UserGuide/latest-Table/Tools-System/Data-Export-Tool_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Tools-System/Data-Export-Tool_timecho.md
@@ -213,25 +213,27 @@ IoTDB 自 **V2.0.9.2** 版本起支持 `tsfile-backup.sh/bat` 脚本，该脚本
 
 ### 3.2 脚本参数
 
-| 参数缩写           | 参数全称                 | 参数含义                                                                                                 | 是否为必填项 | 默认值             |
-| -------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------- | -------------------- |
-| `-sql_dialect` | `--sql_dialect`      | 指定数据模型类型，可选值：`tree`(树模型) 或`table`(表模型)。                                     | 是           | -                  |
-| `-h`           | `--host`             | 本地主机地址。指当前数据所在的 IoTDB 实例 IP。                                                           | 否           | `127.0.0.1`    |
-| `-p`           | `--port`             | 端口号，IoTDB RPC 服务端口。                                                                             | 否           | `6667`         |
-| `-u`           | `--user`             | 用户名，用于登录 IoTDB 验证。                                                                            | 否           | `root`         |
-| `-pw`          | `--password`         | 密码，对应用户的IoTDB密码，支持隐藏输入。                                                                | 否           | `root`         |
-| `-t`           | `--target`           | 导出目标目录。在 SCP 模式下，此路径指远程服务器上的绝对物理路径。TsFile 和关联的 Object 目录将导出至此。 | 是           | -                  |
-| `-db`          | `--database`         | 数据库名称 (表模型可选)                                                                                  | 否           | `.*`           |
-| `-table`       | `--table`            | 表名 (表模型可选)                                                                                        | 否           | `.*`           |
-| `-s`           | `--start_time`       | 起始时间。支持 ISO8601 格式（如 2026-01-01T00:00:00）或毫秒时间戳。仅导出该时间点及之后的数据。          | 否           | -                  |
-| `-e`           | `--end_time`         | 截止时间。格式同上。仅导出该时间点之前的数据。                                                           | 否           | -                  |
-| `-th`          | `--target_host`      | 远程目标主机 IP，默认自动识别启动脚本的IP。指定此参数后，脚本将自动配置 Pipe 使用 SCP 模式进行数据传输。 | 否           | -                  |
-| `-tu`          | `--target_host_user` | 远程主机用户名。用于 SSH/SCP 登录目标服务器。                                                            | 否           | -                  |
-| `-tpw`         | `--target_host_pw`   | 远程主机密码。用于远程身份验证，支持隐藏输入。                                                           | 否           | -                  |
-| `-tp`          | `--target_host_port` | 远程 SSH 端口。                                                                                          | 否           | `22`           |
-| `--rate_limit` | `--rate_limit`       | 发送速率限制。单位：字节/秒 (Bytes/s)。防止导出任务占用过多网络带宽。                                    | 否           | -                  |
-| `--plugin_jar` | `--plugin_jar`       | 指定 Pipe 插件的Jar包路径                                                                                | 否           | -                  |
-| `-help`        | `--help`             | 查看帮助                                                                                                 | 否           | -                  |
+| 参数缩写                   | 参数全称                   | 参数含义                                                           | 是否为必填项 | 默认值         |
+|------------------------|------------------------|----------------------------------------------------------------| -------------- |-------------|
+| `-sql_dialect`         | `--sql_dialect`        | 指定数据模型类型，可选值：`tree`(树模型) 或`table`(表模型)。                        | 是           | -           |
+| `-h`                   | `--host`               | 本地主机地址。指当前数据所在的 IoTDB 实例 IP。                                   | 否           | `127.0.0.1` |
+| `-p`                   | `--port`               | 端口号，IoTDB RPC 服务端口。                                            | 否           | `6667`      |
+| `-u`                   | `--user`               | 用户名，用于登录 IoTDB 验证。                                             | 否           | `root`      |
+| `-pw`                  | `--password`           | 密码，对应用户的IoTDB密码，支持隐藏输入。                                        | 否           | `root`      |
+| `-t`                   | `--target`             | 导出目标目录。在 SCP 模式下，此路径指远程服务器上的绝对物理路径。TsFile 和关联的 Object 目录将导出至此。 | 是           | -           |
+| `-db`                  | `--database`           | 数据库名称 (表模型可选)                                                  | 否           | `.*`        |
+| `-table`               | `--table`              | 表名 (表模型可选)                                                     | 否           | `.*`        |
+| `-s`                   | `--start_time`         | 起始时间。支持 ISO8601 格式（如 2026-01-01T00:00:00）或毫秒时间戳。仅导出该时间点及之后的数据。 | 否           | -           |
+| `-e`                   | `--end_time`           | 截止时间。格式同上。仅导出该时间点之前的数据。                                        | 否           | -           |
+| `-th`                  | `--target_host`        | 远程目标主机 IP，默认自动识别启动脚本的IP。指定此参数后，脚本将自动配置 Pipe 使用 SCP 模式进行数据传输。   | 否           | -           |
+| `-tu`                  | `--target_host_user`   | 远程主机用户名。用于 SSH/SCP 登录目标服务器。                                    | 否           | -           |
+| `-tpw`                 | `--target_host_pw`     | 远程主机密码。用于远程身份验证，支持隐藏输入。                                        | 否           | -           |
+| `-tp`                  | `--target_host_port`   | 远程 SSH 端口。                                                     | 否           | `22`        |
+| `--rate_limit`         | `--rate_limit`         | 发送速率限制。单位：字节/秒 (Bytes/s)。防止导出任务占用过多网络带宽。                       | 否           | -           |
+| `--plugin_jar`         | `--plugin_jar`         | 指定 Pipe 插件的Jar包路径                                              | 否           | -           |
+| `--object-parallelism` | `--object-parallelism` | 指定object文件发送最大并行度                                              | 否        | -           |
+| `--object-batch-size`  | `--object-batch-size`  | 限制每个对象文件上传批次的总字节数，用于控制内存占用和单次 SCP 传输大小                         | 否        | -           |
+| `-help`                | `--help`               | 查看帮助                                                           | 否           | -           |
 
 ### 3.3 运行示例
 
@@ -252,3 +254,7 @@ IoTDB 自 **V2.0.9.2** 版本起支持 `tsfile-backup.sh/bat` 脚本，该脚本
 ```Bash
 ./tsfile-backup.sh -sql_dialect table -db test  -table .* -tu luoluoyuyu -tpw  -t /tmp/backup --plugin_jar /local/lib/tsfile-remote-sink-2.0.8-SNAPSHOT-jar-with-dependencies.jar
 ```
+
+注意：SCP 模式导出 Object 类型数据时，为避免出现握手异常、连接失败或 Pipe 频繁启停问题，建议采取以下任一措施：
+* 适当调低配置参数 object-parallelism
+* 按需调大目标机的 MaxStartups，修改后执行 sshd reload 或 sshd restart 使配置生效

--- a/src/zh/UserGuide/latest-Table/User-Manual/Data-Sync_timecho.md
+++ b/src/zh/UserGuide/latest-Table/User-Manual/Data-Sync_timecho.md
@@ -602,6 +602,10 @@ WITH SINK (
 );
 ```
 
+注意：远程导出 Object 类型数据时，为避免出现握手异常、连接失败或 Pipe 频繁启停问题，建议采取以下任一措施：
+* 适当调低配置参数 sink.scp.object-parallelism
+* 按需调大目标机的 MaxStartups，修改后执行 sshd reload 或 sshd restart 使配置生效
+
 **Sink 导出 TSFile 与 Object 格式：**
 
 ```Bash
@@ -805,12 +809,14 @@ pipe_all_sinks_rate_limit_bytes_per_second=-1
 
 #### tsfile-remote-sink
 
-| **参数**                             | **描述**                            | **value 取值范围**           | **是否必填** | **默认值** |
-|------------------------------------|-----------------------------------|--------------------------|----------|---------|
-| sink                               | 组件名称                              | String: tsfile-remote-sink | 是        | -       |
-| sink.scp.host                      | 远程主机 IP                           | String                   | 是        | -       |
-| sink.scp.port                      | 远程 SSH 端口                         | Long                     | 否        | 22      |
-| sink.scp.user                      | 远程 SSH 用户                         | String                   | 是        | -       |
-| sink.scp.password                  | 远程 SSH 密码                         | String                   | 是        | -       |
-| sink.scp.remote-path               | 远程目标目录                            | String                   | 是        | -       |
-| sink.rate-limit-bytes-per-second   | 单位：字节/秒。开启限速时生效。rate-limit<=0不限速  | Long                     | 否        | 0       |
+| **参数**                            | **描述**                               | **value 取值范围**             | **是否必填** | **默认值**      |
+|-----------------------------------|--------------------------------------|----------------------------|----------|--------------|
+| sink                              | 组件名称                                 | String: tsfile-remote-sink | 是        | -            |
+| sink.scp.host                     | 远程主机 IP                              | String                     | 是        | -            |
+| sink.scp.port                     | 远程 SSH 端口                            | Long                       | 否        | 22           |
+| sink.scp.user                     | 远程 SSH 用户                            | String                     | 是        | -            |
+| sink.scp.password                 | 远程 SSH 密码                            | String                     | 是        | -            |
+| sink.scp.remote-path              | 远程目标目录                               | String                     | 是        | -            |
+| sink.rate-limit-bytes-per-second  | 单位：字节/秒。开启限速时生效。rate-limit<=0不限速     | Long                       | 否        | 0            |
+| sink.scp.object-parallelism       | object文件发送最大并行度                      | Long                       | 否        | `min（cpu/4，16）` |
+| sink.scp.object-batch-size-bytes  | 单次异步线程发送的最大Object文件大小, 单位 MB         | Long                       | 否        | 200          |


### PR DESCRIPTION
Note: When exporting Object-type data in SCP mode, to avoid handshake exceptions, connection failures, or frequent Pipe restarts, it is recommended to take any of the following measures:
1. Appropriately lower the configuration parameter sink.scp.object-parallelism
2. Increase the MaxStartups value on the target machine as needed. After modification, execute sshd reload or sshd restart for the configuration to take effect.