### PR TITLE
Fix zh doc spacing and table row issues

### DIFF
--- a/src/zh/UserGuide/Master/Table/SQL-Manual/Basis-Function_apache.md
+++ b/src/zh/UserGuide/Master/Table/SQL-Manual/Basis-Function_apache.md
@@ -2400,8 +2400,7 @@ SESSION(data [PARTITION BY(pkeys, ...)] [ORDER BY(okeys, ...)], timecol, gap)
 | 参数名  | 参数类型 | 参数属性                 | 描述                                   |
 | --------- | ---------- | -------------------------- | ---------------------------------------- |
 | DATA    | 表参数   | SET SEMANTICPASS THROUGH | 输入表通过 pkeys、okeys 指定分区和排序 |
-| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名
-|
+| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名 |
 | GAP     | 标量参数 | 长整数类型               | 会话间隔阈值                           |
 
 #### 12.2.4 返回结果

--- a/src/zh/UserGuide/Master/Table/SQL-Manual/Basis-Function_timecho.md
+++ b/src/zh/UserGuide/Master/Table/SQL-Manual/Basis-Function_timecho.md
@@ -2401,8 +2401,7 @@ SESSION(data [PARTITION BY(pkeys, ...)] [ORDER BY(okeys, ...)], timecol, gap)
 | 参数名  | 参数类型 | 参数属性                 | 描述                                   |
 | --------- | ---------- | -------------------------- | ---------------------------------------- |
 | DATA    | 表参数   | SET SEMANTICPASS THROUGH | 输入表通过 pkeys、okeys 指定分区和排序 |
-| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名
-|
+| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名 |
 | GAP     | 标量参数 | 长整数类型               | 会话间隔阈值                           |
 
 #### 12.2.4 返回结果

--- a/src/zh/UserGuide/Master/Table/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/Master/Table/User-Manual/Load-Balance.md
@@ -226,7 +226,7 @@ migrate region 3 from 1 to 6
 
 ### 2.1 ConfigNode 节点维护
 
-ConfigNode 节点维护分为 ConfigNod e添加和移除两种操作，有两个常见使用场景：
+ConfigNode 节点维护分为 ConfigNode 添加和移除两种操作，有两个常见使用场景：
 
 * 集群扩展：如集群中只有1个 ConfigNode 时，希望增加 ConfigNode 以提升 ConfigNode 节点高可用性，则可以添加2个 ConfigNode，使得集群中有3个 ConfigNode。
 * 集群故障恢复：1个 ConfigNode 所在机器发生故障，使得该 ConfigNode 无法正常运行，此时可以移除该 ConfigNode，然后添加一个新的 ConfigNode 进入集群。

--- a/src/zh/UserGuide/Master/Tree/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/Master/Tree/User-Manual/Load-Balance.md
@@ -227,7 +227,7 @@ migrate region 3 from 1 to 6
 
 ### 2.1 ConfigNode 节点维护
 
-ConfigNode 节点维护分为 ConfigNod e添加和移除两种操作，有两个常见使用场景：
+ConfigNode 节点维护分为 ConfigNode 添加和移除两种操作，有两个常见使用场景：
 
 * 集群扩展：如集群中只有1个 ConfigNode 时，希望增加 ConfigNode 以提升 ConfigNode 节点高可用性，则可以添加2个 ConfigNode，使得集群中有3个 ConfigNode。
 * 集群故障恢复：1个 ConfigNode 所在机器发生故障，使得该 ConfigNode 无法正常运行，此时可以移除该 ConfigNode，然后添加一个新的 ConfigNode 进入集群。

--- a/src/zh/UserGuide/latest-Table/SQL-Manual/Basis-Function_apache.md
+++ b/src/zh/UserGuide/latest-Table/SQL-Manual/Basis-Function_apache.md
@@ -2400,8 +2400,7 @@ SESSION(data [PARTITION BY(pkeys, ...)] [ORDER BY(okeys, ...)], timecol, gap)
 | 参数名  | 参数类型 | 参数属性                 | 描述                                   |
 | --------- | ---------- | -------------------------- | ---------------------------------------- |
 | DATA    | 表参数   | SET SEMANTICPASS THROUGH | 输入表通过 pkeys、okeys 指定分区和排序 |
-| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名
-|
+| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名 |
 | GAP     | 标量参数 | 长整数类型               | 会话间隔阈值                           |
 
 #### 12.2.4 返回结果

--- a/src/zh/UserGuide/latest-Table/SQL-Manual/Basis-Function_timecho.md
+++ b/src/zh/UserGuide/latest-Table/SQL-Manual/Basis-Function_timecho.md
@@ -2401,8 +2401,7 @@ SESSION(data [PARTITION BY(pkeys, ...)] [ORDER BY(okeys, ...)], timecol, gap)
 | 参数名  | 参数类型 | 参数属性                 | 描述                                   |
 | --------- | ---------- | -------------------------- | ---------------------------------------- |
 | DATA    | 表参数   | SET SEMANTICPASS THROUGH | 输入表通过 pkeys、okeys 指定分区和排序 |
-| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名
-|
+| TIMECOL | 标量参数 | 字符串类型默认值：'time' | 时间列名 |
 | GAP     | 标量参数 | 长整数类型               | 会话间隔阈值                           |
 
 #### 12.2.4 返回结果

--- a/src/zh/UserGuide/latest-Table/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/latest-Table/User-Manual/Load-Balance.md
@@ -226,7 +226,7 @@ migrate region 3 from 1 to 6
 
 ### 2.1 ConfigNode 节点维护
 
-ConfigNode 节点维护分为 ConfigNod e添加和移除两种操作，有两个常见使用场景：
+ConfigNode 节点维护分为 ConfigNode 添加和移除两种操作，有两个常见使用场景：
 
 * 集群扩展：如集群中只有1个 ConfigNode 时，希望增加 ConfigNode 以提升 ConfigNode 节点高可用性，则可以添加2个 ConfigNode，使得集群中有3个 ConfigNode。
 * 集群故障恢复：1个 ConfigNode 所在机器发生故障，使得该 ConfigNode 无法正常运行，此时可以移除该 ConfigNode，然后添加一个新的 ConfigNode 进入集群。

--- a/src/zh/UserGuide/latest/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/latest/User-Manual/Load-Balance.md
@@ -227,7 +227,7 @@ migrate region 3 from 1 to 6
 
 ### 2.1 ConfigNode 节点维护
 
-ConfigNode 节点维护分为 ConfigNod e添加和移除两种操作，有两个常见使用场景：
+ConfigNode 节点维护分为 ConfigNode 添加和移除两种操作，有两个常见使用场景：
 
 * 集群扩展：如集群中只有1个 ConfigNode 时，希望增加 ConfigNode 以提升 ConfigNode 节点高可用性，则可以添加2个 ConfigNode，使得集群中有3个 ConfigNode。
 * 集群故障恢复：1个 ConfigNode 所在机器发生故障，使得该 ConfigNode 无法正常运行，此时可以移除该 ConfigNode，然后添加一个新的 ConfigNode 进入集群。


### PR DESCRIPTION
## Summary
- Fix the split ConfigNod e text in zh Load-Balance docs across Master, latest, and latest-Table
- Merge the broken TIMECOL table row in zh Basis-Function docs across Master/Table and latest-Table

## Validation
- rg targeted checks for ConfigNod e and broken standalone | rows
- git diff --cached --check