### PR TITLE
docs: add Windows command examples to deployment docs

### DIFF
--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -179,6 +179,7 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 1. Start the first ConfigNode (`iotdb-1`) as the seed node
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
@@ -199,6 +200,7 @@ If the startup fails, refer to the [Common Issues](#5-common-issues) section bel
 On each server, navigate to the `sbin` directory and start the DataNode:
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
 

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -181,6 +181,13 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 ```Bash
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-confignode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-confignode.bat
   ```
 
 2. Start the remaining ConfigNodes (`iotdb-2` and `iotdb-3`) in sequence.
@@ -194,6 +201,13 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ```Bash
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-datanode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-datanode.bat
   ```
 
 ### 3.6 Start CLI
@@ -205,7 +219,11 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ./start-cli.sh -sql_dialect table
 
 # For Windows
-./start-cli.bat -sql_dialect table
+# Before version V2.0.4.x
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x and later versions
+.\windows\start-cli-table.bat
 ```
 
 ### 3.7 One-click Cluster Start and Stop

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -179,6 +179,7 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 1. Start the first ConfigNode (`iotdb-1`) as the seed node
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
@@ -199,6 +200,7 @@ If the startup fails, refer to the [Common Issues](#5-common-issues) section bel
 On each server, navigate to the `sbin` directory and start the DataNode:
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
 

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -181,6 +181,13 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 ```Bash
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-confignode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-confignode.bat
   ```
 
 2. Start the remaining ConfigNodes (`iotdb-2` and `iotdb-3`) in sequence.
@@ -194,6 +201,13 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ```Bash
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-datanode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-datanode.bat
   ```
 
 ### 3.6 Activate the Database

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -67,6 +67,7 @@ Ensure that configurations for A and B are consistent for optimal dual-active pe
 - Connect to the database on Machine A using the CLI tool from the `sbin` directory:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-cli.sh  -h iotdb-1
 
 # Windows
@@ -97,6 +98,7 @@ with sink (
 - Connect to the database on Machine B:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-cli.sh  -h iotdb-2
 
 # Windows
@@ -168,6 +170,7 @@ To stop the dual-active instances:
 On machine A:
 
 ```SQL
+# Unix/OS X
 ./sbin/start-cli.sh -h iotdb-1  # Log in to CLI
 IoTDB> stop pipe AB             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service
@@ -187,6 +190,7 @@ IoTDB> stop pipe AB
 On machine B:
 
 ```SQL
+# Unix/OS X
 ./sbin/start-cli.sh -h iotdb-2  # Log in to CLI
 IoTDB> stop pipe BA             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -68,6 +68,13 @@ Ensure that configurations for A and B are consistent for optimal dual-active pe
 
 ```Bash
 ./sbin/start-cli.sh  -h iotdb-1
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-1
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-1
 ```
 
 - Then create and start a data synchronization process. Use the following SQL command:
@@ -91,6 +98,13 @@ with sink (
 
 ```Bash
 ./sbin/start-cli.sh  -h iotdb-2
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-2
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-2
 ```
 
 - Then create and start the synchronization process with the following SQL command:
@@ -157,6 +171,17 @@ On machine A:
 ./sbin/start-cli.sh -h iotdb-1  # Log in to CLI
 IoTDB> stop pipe AB             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-1
+IoTDB> stop pipe AB
+.\sbin\stop-standalone.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-1
+IoTDB> stop pipe AB
+.\sbin\windows\stop-standalone.bat
 ```
 
 On machine B:
@@ -165,4 +190,15 @@ On machine B:
 ./sbin/start-cli.sh -h iotdb-2  # Log in to CLI
 IoTDB> stop pipe BA             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-2
+IoTDB> stop pipe BA
+.\sbin\stop-standalone.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-2
+IoTDB> stop pipe BA
+.\sbin\windows\stop-standalone.bat
 ```

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -60,6 +60,17 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
   ./sbin/stop-standalone.sh      #Stop confignode and datanode first
   ./sbin/start-confignode.sh  -d #Start confignode
   ./sbin/start-datanode.sh  -d   #Start datanode 
+
+  # Windows
+  # Before version V2.0.4.x
+  .\sbin\stop-standalone.bat
+  .\sbin\start-confignode.bat
+  .\sbin\start-datanode.bat
+
+  # V2.0.4.x and later versions
+  .\sbin\windows\stop-standalone.bat
+  .\sbin\windows\start-confignode.bat
+  .\sbin\windows\start-datanode.bat
   ```
 
 3. After restarting, confirm the running status of each node through the client. If all nodes are running, the configuration is successful.

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -57,6 +57,7 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
 2. Restart all nodes. After modifying the monitoring configurations on all 3 nodes, restart the ConfigNode and DataNode services:
 
 ```Bash
+  # Unix/OS X
   ./sbin/stop-standalone.sh      #Stop confignode and datanode first
   ./sbin/start-confignode.sh  -d #Start confignode
   ./sbin/start-datanode.sh  -d   #Start datanode 

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -151,6 +151,7 @@ Set the following parameters in `conf/iotdb-system.properties`. Refer to `conf/i
 Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
 # Windows
@@ -170,6 +171,7 @@ If the startup fails, refer to the [Common Issues](#3-common-issues)。 section 
 Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
 
 # Windows

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -152,6 +152,13 @@ Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-confignode.bat
 ```
 
 If the startup fails, refer to the [Common Issues](#3-common-issues)。 section below for troubleshooting.
@@ -164,6 +171,13 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 Start CLI
@@ -175,7 +189,11 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 ./start-cli.sh -sql_dialect table
 
 # For Windows
-./start-cli.bat -sql_dialect table
+# Before version V2.0.4.x
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x and later versions
+.\windows\start-cli-table.bat
 ```
 
 ## 3. Common Issues

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -148,6 +148,7 @@ Set the following parameters in `conf/iotdb-system.properties`. Refer to `conf/i
 Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
 # Windows
@@ -167,6 +168,7 @@ If the startup fails, refer to the [Common Issues](#3-common-issues)。 section 
 Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
 
 # Windows

--- a/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -149,6 +149,13 @@ Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-confignode.bat
 ```
 
 If the startup fails, refer to the [Common Issues](#3-common-issues)。 section below for troubleshooting.
@@ -161,6 +168,13 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 Activate the Database

--- a/src/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
@@ -30,6 +30,7 @@ There are several ways to identify the version of IoTDB that you are using:
 * Launch IoTDB's Command Line Interface:
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -110,6 +111,7 @@ Yes. IoTDB has intense integration with Open Source Ecosystem. IoTDB supports [S
 The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:00:00.001```), if you want to display time in timestamp type or other readable format, add parameter ```-disableISO8601``` in start command:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
@@ -39,6 +39,16 @@ There are several ways to identify the version of IoTDB that you are using:
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x and later versions
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * Check pom.xml file:
 
 ```
@@ -101,6 +111,16 @@ The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:0
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x and later versions
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.6 How to handle error `IndexOutOfBoundsException` from `org.apache.ratis.grpc.server.GrpcLogAppender`?

--- a/src/UserGuide/Master/Table/User-Manual/Load-Balance.md
+++ b/src/UserGuide/Master/Table/User-Manual/Load-Balance.md
@@ -169,6 +169,13 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 5. Connect to the original cluster via CLI command for post-scaling verification.
@@ -178,7 +185,11 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
 
   # Windows
+  # Before version V2.0.4.x
   .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x and later versions
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. Execute commands for verification.
@@ -316,7 +327,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x and later
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 **Parameter description:**

--- a/src/UserGuide/Master/Table/User-Manual/Load-Balance.md
+++ b/src/UserGuide/Master/Table/User-Manual/Load-Balance.md
@@ -168,6 +168,7 @@ vim iotdb-system.properties
 Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
 
 # Windows

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -173,6 +173,7 @@ Open DataNode Configuration File `./conf/iotdb-system.properties`,Set the follow
 Start the first confignode of IoTDB-1 first, ensuring that the seed confignode node starts first, and then start the second and third confignode nodes in sequence
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
 
@@ -192,6 +193,7 @@ If the startup fails, please refer to [Common Questions](#common-questions).
  Enter the `sbin` directory of iotdb and start three datanode nodes in sequence:
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
 
@@ -208,6 +210,7 @@ cd sbin
 Can be executed directly Cli startup script in `./sbin`  directory:
 
 ```Plain
+# Unix/OS X
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
 
 # Windows

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -175,6 +175,13 @@ Start the first confignode of IoTDB-1 first, ensuring that the seed confignode n
 ```Bash
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-confignode.bat
 ```
 
 If the startup fails, please refer to [Common Questions](#common-questions).
@@ -187,6 +194,13 @@ If the startup fails, please refer to [Common Questions](#common-questions).
 ```Bash
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 Verify Deployment
@@ -195,6 +209,13 @@ Can be executed directly Cli startup script in `./sbin`  directory:
 
 ```Plain
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
+
+# Windows
+# Before version V2.0.4.x
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x and later versions
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
 After successful startup, the following interface will appear displaying successful installation of IOTDB.

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -180,6 +180,7 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 1. Start the first ConfigNode (`iotdb-1`) as the seed node
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
 
@@ -200,6 +201,7 @@ cd sbin
 On each server, navigate to the `sbin` directory and start the DataNode:
 
 ```Go
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
 

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -182,6 +182,13 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 ```Bash
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-confignode.bat
 ```
 
 2. Start the remaining ConfigNodes (`iotdb-2` and `iotdb-3`) in sequence.
@@ -195,6 +202,13 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ```Go
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-datanode.bat
 ```
 
 ### 3.6 Activate Database
@@ -211,6 +225,19 @@ Shell > bash sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root
 
 # V2.0.6.x and later versions
 Shell > bash sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw TimechoDB@2021
+```
+
+The Windows system startup commands are as follows:
+
+```shell
+# Before version V2.0.4.x
+Shell > sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root
+
+# V2.0.4.x and later versions, before version V2.0.6.x
+Shell > sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root
+
+# V2.0.6.x and later versions
+Shell > sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw TimechoDB@2021
 ```
 
 The Windows system startup commands are as follows:

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -60,6 +60,7 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 - Create a data synchronization process on machine A, where the data on machine A is automatically synchronized to machine B. Use the cli tool in the sbin directory to connect to the IoTDB database on machine A:
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-1
 
     # Windows
@@ -91,6 +92,7 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 - Create a data synchronization process on machine B, where the data on machine B is automatically synchronized to machine A. Use the cli tool in the sbin directory to connect to the IoTDB database on machine B
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-2
 
     # Windows
@@ -163,6 +165,7 @@ Ensure that every pipe is in the RUNNING state.
 - Execute the following command on machine A:
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-1  #Log in to CLI
     IoTDB> stop pipe AB             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service
@@ -182,6 +185,7 @@ Ensure that every pipe is in the RUNNING state.
 - Execute the following command on machine B:
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-2  #Log in to CLI
     IoTDB> stop pipe BA             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -61,6 +61,13 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-1
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-1
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-1
     ```
 
 - Create and start the data synchronization command with the following SQL:
@@ -85,6 +92,13 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-2
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-2
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-2
     ```
 
     Create and start the pipe with the following SQL:
@@ -152,6 +166,17 @@ Ensure that every pipe is in the RUNNING state.
     ./sbin/start-cli.sh -h iotdb-1  #Log in to CLI
     IoTDB> stop pipe AB             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\windows\stop-standalone.bat
     ```
 
 - Execute the following command on machine B:
@@ -160,5 +185,16 @@ Ensure that every pipe is in the RUNNING state.
     ./sbin/start-cli.sh -h iotdb-2  #Log in to CLI
     IoTDB> stop pipe BA             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\windows\stop-standalone.bat
     ```
 

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -58,6 +58,7 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
 2. Restart all nodes. After modifying the monitoring indicator configuration of three nodes, the confignode and datanode services of all nodes can be restarted:
 
 ```Bash
+# Unix/OS X
 ./sbin/stop-standalone.sh      #Stop confignode and datanode first
 ./sbin/start-confignode.sh  -d #Start confignode
 ./sbin/start-datanode.sh  -d   #Start datanode 

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -61,6 +61,17 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
 ./sbin/stop-standalone.sh      #Stop confignode and datanode first
 ./sbin/start-confignode.sh  -d #Start confignode
 ./sbin/start-datanode.sh  -d   #Start datanode 
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\stop-standalone.bat
+.\sbin\start-confignode.bat
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\stop-standalone.bat
+.\sbin\windows\start-confignode.bat
+.\sbin\windows\start-datanode.bat
 ```
 
 3. After restarting, confirm the running status of each node through the client. If the status is Running, it indicates successful configuration:

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -143,6 +143,13 @@ Enter the sbin directory of iotdb and start confignode
 
 ```Shell
 ./start-confignode.sh    -d      #The "- d" parameter will start in the background 
+
+# Windows
+# Before version V2.0.4.x
+.\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-confignode.bat
 ```
 If the startup fails, please refer to [Common Questions](#common-questions).
 
@@ -153,6 +160,13 @@ Enter the sbin directory of iotdb and start datanode:
 ```Shell
 cd sbin
 ./start-datanode.sh   -d   #The "- d" parameter will start in the background 
+
+# Windows
+# Before version V2.0.4.x
+.\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-datanode.bat
 ```
 
 ### 2.6 Verify Deployment
@@ -161,6 +175,13 @@ Can be executed directly/ Cli startup script in sbin directory:
 
 ```Shell
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
+
+# Windows
+# Before version V2.0.4.x
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x and later versions
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
 After successful startup, the following interface will appear displaying successful installation of IOTDB.

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -142,6 +142,7 @@ Open the DataNode configuration file (./conf/iotdb-system. properties file) and 
 Enter the sbin directory of iotdb and start confignode
 
 ```Shell
+# Unix/OS X
 ./start-confignode.sh    -d      #The "- d" parameter will start in the background 
 
 # Windows
@@ -158,6 +159,7 @@ If the startup fails, please refer to [Common Questions](#common-questions).
 Enter the sbin directory of iotdb and start datanode:
 
 ```Shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #The "- d" parameter will start in the background 
 
@@ -174,6 +176,7 @@ cd sbin
 Can be executed directly/ Cli startup script in sbin directory:
 
 ```Shell
+# Unix/OS X
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
 
 # Windows

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -147,6 +147,7 @@ Set the following parameters in `conf/iotdb-system.properties`. Refer to `conf/i
 Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
 # Windows
@@ -164,6 +165,7 @@ Navigate to the `sbin` directory and start ConfigNode:
 Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ````shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
 
 # Windows

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -148,6 +148,13 @@ Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-confignode.bat
 ```
 
  If the startup fails, refer to the  [**Common Problem**](#Common Problem) section below for troubleshooting.
@@ -158,6 +165,13 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ````shell
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ````
 
 ### 2.6 Activate Database

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -131,6 +131,7 @@ To ensure the Workbench installation package you obtained is complete and valid,
 2. Restart all nodes. After modifying the monitoring indicator configuration of three nodes, the confignode and datanode services of all nodes can be restarted:
 
     ```shell
+    # Unix/OS X
     ./sbin/stop-standalone.sh      #Stop confignode and datanode first
     ./sbin/start-confignode.sh  -d #Start confignode
     ./sbin/start-datanode.sh  -d   #Start datanode 

--- a/src/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -39,9 +39,7 @@ The instructions for using the visualization console tool can be found in the [I
 |         Database         |            IoTDB            |         Requires V1.2.0 Enterprise Edition and above         |   You can contact business or technical support to obtain    |
 |         Console          | IoTDB-Workbench-`<version>` |                              -                               | You can choose according to the appendix version comparison table and contact business or technical support to obtain it |
 
-## 2. Installation Steps
-
-### 2.1 Pre-installation Check
+### Pre-installation Check
 
 To ensure the Workbench installation package you obtained is complete and valid, we recommend performing an SHA512 verification before proceeding with the installation and deployment.
 
@@ -70,7 +68,9 @@ To ensure the Workbench installation package you obtained is complete and valid,
 - If the verification results do not match, please contact the Timecho Team to re-obtain the installation package.
 - If a "file not found" prompt appears during verification, check whether the file path is correct or if the installation package has been fully downloaded.
 
-### 2.2 IoTDB enables monitoring indicator collection
+## 2. Installation Steps
+
+### 2.1 IoTDB enables monitoring indicator collection
 
 1. Open the monitoring configuration item. The configuration items related to monitoring in IoTDB are disabled by default. Before deploying the monitoring panel, you need to open the relevant configuration items (note that the service needs to be restarted after enabling monitoring configuration).
 
@@ -134,13 +134,24 @@ To ensure the Workbench installation package you obtained is complete and valid,
     ./sbin/stop-standalone.sh      #Stop confignode and datanode first
     ./sbin/start-confignode.sh  -d #Start confignode
     ./sbin/start-datanode.sh  -d   #Start datanode 
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\stop-standalone.bat
+    .\sbin\start-confignode.bat
+    .\sbin\start-datanode.bat
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\stop-standalone.bat
+    .\sbin\windows\start-confignode.bat
+    .\sbin\windows\start-datanode.bat
     ```
 
 3. After restarting, confirm the running status of each node through the client. If the status is Running, it indicates successful configuration:
 
     ![](/img/%E5%90%AF%E5%8A%A8.png)
 
-### 2.3 Install and configure Prometheus
+### 2.2 Install and configure Prometheus
 
 1. Download the Prometheus installation package, which requires installation of V2.30.3 and above. You can go to the Prometheus official website to download it (https://prometheus.io/docs/introduction/first_steps/)
 2. Unzip the installation package and enter the unzipped folder:
@@ -186,7 +197,7 @@ To ensure the Workbench installation package you obtained is complete and valid,
     </div>
 
 
-### 2.4 Install Workbench
+### 2.3 Install Workbench
 
 1. Enter the config directory of iotdb Workbench -`<version>`
 
@@ -219,7 +230,7 @@ To ensure the Workbench installation package you obtained is complete and valid,
     ![](/img/workbench-en.png)
 
 
-### 2.5 Configure Instance Information
+### 2.4 Configure Instance Information
 
 1. Configure instance information: You only need to fill in the following information to connect to the instance
 

--- a/src/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
@@ -39,6 +39,16 @@ There are several ways to identify the version of IoTDB that you are using:
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x and later versions
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * Check pom.xml file:
 
 ```
@@ -150,6 +160,16 @@ The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:0
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x and later versions
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.9 How to handle error `IndexOutOfBoundsException` from `org.apache.ratis.grpc.server.GrpcLogAppender`?

--- a/src/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
@@ -30,6 +30,7 @@ There are several ways to identify the version of IoTDB that you are using:
 * Launch IoTDB's Command Line Interface:
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -159,6 +160,7 @@ IoTDB> show timeseries root.fit.d1.*
 The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:00:00.001```), if you want to display time in timestamp type or other readable format, add parameter ```-disableISO8601``` in start command:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/UserGuide/Master/Tree/User-Manual/Load-Balance.md
+++ b/src/UserGuide/Master/Tree/User-Manual/Load-Balance.md
@@ -169,6 +169,13 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 5. Connect to the original cluster via CLI command for post-scaling verification.
@@ -178,7 +185,11 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
 
   # Windows
+  # Before version V2.0.4.x
   .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x and later versions
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. Execute commands for verification.
@@ -315,7 +326,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x and later
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 **Parameter description:**

--- a/src/UserGuide/Master/Tree/User-Manual/Load-Balance.md
+++ b/src/UserGuide/Master/Tree/User-Manual/Load-Balance.md
@@ -168,6 +168,7 @@ vim iotdb-system.properties
 Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
 
 # Windows

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -179,6 +179,7 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 1. Start the first ConfigNode (`iotdb-1`) as the seed node
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
@@ -199,6 +200,7 @@ If the startup fails, refer to the [Common Issues](#5-common-issues) section bel
 On each server, navigate to the `sbin` directory and start the DataNode:
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
 

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -181,6 +181,13 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 ```Bash
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-confignode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-confignode.bat
   ```
 
 2. Start the remaining ConfigNodes (`iotdb-2` and `iotdb-3`) in sequence.
@@ -194,6 +201,13 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ```Bash
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-datanode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-datanode.bat
   ```
 
 ### 3.6 Start CLI
@@ -205,7 +219,11 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ./start-cli.sh -sql_dialect table
 
 # For Windows
-./start-cli.bat -sql_dialect table
+# Before version V2.0.4.x
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x and later versions
+.\windows\start-cli-table.bat
 ```
 
 ### 3.7 One-click Cluster Start and Stop

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -179,6 +179,7 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 1. Start the first ConfigNode (`iotdb-1`) as the seed node
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
@@ -199,6 +200,7 @@ If the startup fails, refer to the [Common Issues](#5-common-issues) section bel
 On each server, navigate to the `sbin` directory and start the DataNode:
 
 ```Bash
+  # Unix/OS X
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
 

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -181,6 +181,13 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 ```Bash
   cd sbin
   ./start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-confignode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-confignode.bat
   ```
 
 2. Start the remaining ConfigNodes (`iotdb-2` and `iotdb-3`) in sequence.
@@ -194,6 +201,13 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ```Bash
   cd sbin
   ./start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+  # Windows
+  # Before version V2.0.4.x
+  .\start-datanode.bat
+
+  # V2.0.4.x and later versions
+  .\windows\start-datanode.bat
   ```
 
 ### 3.6 Activate the Database

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -67,6 +67,7 @@ Ensure that configurations for A and B are consistent for optimal dual-active pe
 - Connect to the database on Machine A using the CLI tool from the `sbin` directory:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-cli.sh  -h iotdb-1
 
 # Windows
@@ -97,6 +98,7 @@ with sink (
 - Connect to the database on Machine B:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-cli.sh  -h iotdb-2
 
 # Windows
@@ -168,6 +170,7 @@ To stop the dual-active instances:
 On machine A:
 
 ```SQL
+# Unix/OS X
 ./sbin/start-cli.sh -h iotdb-1  # Log in to CLI
 IoTDB> stop pipe AB             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service
@@ -187,6 +190,7 @@ IoTDB> stop pipe AB
 On machine B:
 
 ```SQL
+# Unix/OS X
 ./sbin/start-cli.sh -h iotdb-2  # Log in to CLI
 IoTDB> stop pipe BA             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -68,6 +68,13 @@ Ensure that configurations for A and B are consistent for optimal dual-active pe
 
 ```Bash
 ./sbin/start-cli.sh  -h iotdb-1
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-1
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-1
 ```
 
 - Then create and start a data synchronization process. Use the following SQL command:
@@ -91,6 +98,13 @@ with sink (
 
 ```Bash
 ./sbin/start-cli.sh  -h iotdb-2
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-2
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-2
 ```
 
 - Then create and start the synchronization process with the following SQL command:
@@ -157,6 +171,17 @@ On machine A:
 ./sbin/start-cli.sh -h iotdb-1  # Log in to CLI
 IoTDB> stop pipe AB             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-1
+IoTDB> stop pipe AB
+.\sbin\stop-standalone.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-1
+IoTDB> stop pipe AB
+.\sbin\windows\stop-standalone.bat
 ```
 
 On machine B:
@@ -165,4 +190,15 @@ On machine B:
 ./sbin/start-cli.sh -h iotdb-2  # Log in to CLI
 IoTDB> stop pipe BA             # Stop data synchronization
 ./sbin/stop-standalone.sh       # Stop database service
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-cli.bat -h iotdb-2
+IoTDB> stop pipe BA
+.\sbin\stop-standalone.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-cli.bat -h iotdb-2
+IoTDB> stop pipe BA
+.\sbin\windows\stop-standalone.bat
 ```

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -60,6 +60,17 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
   ./sbin/stop-standalone.sh      #Stop confignode and datanode first
   ./sbin/start-confignode.sh  -d #Start confignode
   ./sbin/start-datanode.sh  -d   #Start datanode 
+
+  # Windows
+  # Before version V2.0.4.x
+  .\sbin\stop-standalone.bat
+  .\sbin\start-confignode.bat
+  .\sbin\start-datanode.bat
+
+  # V2.0.4.x and later versions
+  .\sbin\windows\stop-standalone.bat
+  .\sbin\windows\start-confignode.bat
+  .\sbin\windows\start-datanode.bat
   ```
 
 3. After restarting, confirm the running status of each node through the client. If all nodes are running, the configuration is successful.

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -57,6 +57,7 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
 2. Restart all nodes. After modifying the monitoring configurations on all 3 nodes, restart the ConfigNode and DataNode services:
 
 ```Bash
+  # Unix/OS X
   ./sbin/stop-standalone.sh      #Stop confignode and datanode first
   ./sbin/start-confignode.sh  -d #Start confignode
   ./sbin/start-datanode.sh  -d   #Start datanode 

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -151,6 +151,7 @@ Set the following parameters in `conf/iotdb-system.properties`. Refer to `conf/i
 Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
 # Windows
@@ -170,6 +171,7 @@ If the startup fails, refer to the [Common Issues](#3-common-issues)。 section 
 Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
 
 # Windows

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -152,6 +152,13 @@ Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-confignode.bat
 ```
 
 If the startup fails, refer to the [Common Issues](#3-common-issues)。 section below for troubleshooting.
@@ -164,6 +171,13 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 Start CLI
@@ -175,7 +189,11 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 ./start-cli.sh -sql_dialect table
 
 # For Windows
-./start-cli.bat -sql_dialect table
+# Before version V2.0.4.x
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x and later versions
+.\windows\start-cli-table.bat
 ```
 
 ## 3. Common Issues

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -148,6 +148,7 @@ Set the following parameters in `conf/iotdb-system.properties`. Refer to `conf/i
 Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
 # Windows
@@ -167,6 +168,7 @@ If the startup fails, refer to the [Common Issues](#3-common-issues)。 section 
 Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
 
 # Windows

--- a/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -149,6 +149,13 @@ Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-confignode.bat
 ```
 
 If the startup fails, refer to the [Common Issues](#3-common-issues)。 section below for troubleshooting.
@@ -161,6 +168,13 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ```Bash
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 Activate the Database

--- a/src/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
@@ -30,6 +30,7 @@ There are several ways to identify the version of IoTDB that you are using:
 * Launch IoTDB's Command Line Interface:
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -110,6 +111,7 @@ Yes. IoTDB has intense integration with Open Source Ecosystem. IoTDB supports [S
 The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:00:00.001```), if you want to display time in timestamp type or other readable format, add parameter ```-disableISO8601``` in start command:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
@@ -39,6 +39,16 @@ There are several ways to identify the version of IoTDB that you are using:
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x and later versions
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * Check pom.xml file:
 
 ```
@@ -101,6 +111,16 @@ The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:0
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x and later versions
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.6 How to handle error `IndexOutOfBoundsException` from `org.apache.ratis.grpc.server.GrpcLogAppender`?

--- a/src/UserGuide/latest-Table/User-Manual/Load-Balance.md
+++ b/src/UserGuide/latest-Table/User-Manual/Load-Balance.md
@@ -169,6 +169,13 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 5. Connect to the original cluster via CLI command for post-scaling verification.
@@ -178,7 +185,11 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
 
   # Windows
+  # Before version V2.0.4.x
   .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x and later versions
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. Execute commands for verification.
@@ -316,7 +327,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x and later
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 **Parameter description:**

--- a/src/UserGuide/latest-Table/User-Manual/Load-Balance.md
+++ b/src/UserGuide/latest-Table/User-Manual/Load-Balance.md
@@ -168,6 +168,7 @@ vim iotdb-system.properties
 Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
 
 # Windows

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -173,6 +173,7 @@ Open DataNode Configuration File `./conf/iotdb-system.properties`,Set the follow
 Start the first confignode of IoTDB-1 first, ensuring that the seed confignode node starts first, and then start the second and third confignode nodes in sequence
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
 
@@ -192,6 +193,7 @@ If the startup fails, please refer to [Common Questions](#common-questions).
  Enter the `sbin` directory of iotdb and start three datanode nodes in sequence:
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
 
@@ -208,6 +210,7 @@ cd sbin
 Can be executed directly Cli startup script in `./sbin`  directory:
 
 ```Plain
+# Unix/OS X
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
 
 # Windows

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -175,6 +175,13 @@ Start the first confignode of IoTDB-1 first, ensuring that the seed confignode n
 ```Bash
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-confignode.bat
 ```
 
 If the startup fails, please refer to [Common Questions](#common-questions).
@@ -187,6 +194,13 @@ If the startup fails, please refer to [Common Questions](#common-questions).
 ```Bash
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 Verify Deployment
@@ -195,6 +209,13 @@ Can be executed directly Cli startup script in `./sbin`  directory:
 
 ```Plain
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
+
+# Windows
+# Before version V2.0.4.x
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x and later versions
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
 After successful startup, the following interface will appear displaying successful installation of IOTDB.

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -180,6 +180,7 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 1. Start the first ConfigNode (`iotdb-1`) as the seed node
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
 
@@ -200,6 +201,7 @@ cd sbin
 On each server, navigate to the `sbin` directory and start the DataNode:
 
 ```Go
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
 

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -182,6 +182,13 @@ Set the following parameters in `./conf/iotdb-system.properties`. Refer to `./co
 ```Bash
 cd sbin
 ./start-confignode.sh    -d      #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-confignode.bat
 ```
 
 2. Start the remaining ConfigNodes (`iotdb-2` and `iotdb-3`) in sequence.
@@ -195,6 +202,13 @@ On each server, navigate to the `sbin` directory and start the DataNode:
 ```Go
 cd sbin
 ./start-datanode.sh   -d   #"- d" parameter will start in the background
+
+# Windows
+# Before version V2.0.4.x
+.\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-datanode.bat
 ```
 
 ### 3.6 Activate Database
@@ -211,6 +225,19 @@ Shell > bash sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root
 
 # V2.0.6.x and later versions
 Shell > bash sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw TimechoDB@2021
+```
+
+The Windows system startup commands are as follows:
+
+```shell
+# Before version V2.0.4.x
+Shell > sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root
+
+# V2.0.4.x and later versions, before version V2.0.6.x
+Shell > sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root
+
+# V2.0.6.x and later versions
+Shell > sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw TimechoDB@2021
 ```
 
 The Windows system startup commands are as follows:

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -60,6 +60,7 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 - Create a data synchronization process on machine A, where the data on machine A is automatically synchronized to machine B. Use the cli tool in the sbin directory to connect to the IoTDB database on machine A:
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-1
 
     # Windows
@@ -91,6 +92,7 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 - Create a data synchronization process on machine B, where the data on machine B is automatically synchronized to machine A. Use the cli tool in the sbin directory to connect to the IoTDB database on machine B
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-2
 
     # Windows
@@ -163,6 +165,7 @@ Ensure that every pipe is in the RUNNING state.
 - Execute the following command on machine A:
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-1  #Log in to CLI
     IoTDB> stop pipe AB             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service
@@ -182,6 +185,7 @@ Ensure that every pipe is in the RUNNING state.
 - Execute the following command on machine B:
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-2  #Log in to CLI
     IoTDB> stop pipe BA             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -61,6 +61,13 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-1
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-1
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-1
     ```
 
 - Create and start the data synchronization command with the following SQL:
@@ -85,6 +92,13 @@ Install IoTDB on two machines separately, and refer to the deployment documentat
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-2
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-2
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-2
     ```
 
     Create and start the pipe with the following SQL:
@@ -152,6 +166,17 @@ Ensure that every pipe is in the RUNNING state.
     ./sbin/start-cli.sh -h iotdb-1  #Log in to CLI
     IoTDB> stop pipe AB             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\windows\stop-standalone.bat
     ```
 
 - Execute the following command on machine B:
@@ -160,5 +185,16 @@ Ensure that every pipe is in the RUNNING state.
     ./sbin/start-cli.sh -h iotdb-2  #Log in to CLI
     IoTDB> stop pipe BA             #Stop the data synchronization process
     ./sbin/stop-standalone.sh       #Stop database service
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\windows\stop-standalone.bat
     ```
 

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -58,6 +58,7 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
 2. Restart all nodes. After modifying the monitoring indicator configuration of three nodes, the confignode and datanode services of all nodes can be restarted:
 
 ```Bash
+# Unix/OS X
 ./sbin/stop-standalone.sh      #Stop confignode and datanode first
 ./sbin/start-confignode.sh  -d #Start confignode
 ./sbin/start-datanode.sh  -d   #Start datanode 

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -61,6 +61,17 @@ Taking the 3C3D cluster as an example, the monitoring configuration that needs t
 ./sbin/stop-standalone.sh      #Stop confignode and datanode first
 ./sbin/start-confignode.sh  -d #Start confignode
 ./sbin/start-datanode.sh  -d   #Start datanode 
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\stop-standalone.bat
+.\sbin\start-confignode.bat
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\stop-standalone.bat
+.\sbin\windows\start-confignode.bat
+.\sbin\windows\start-datanode.bat
 ```
 
 3. After restarting, confirm the running status of each node through the client. If the status is Running, it indicates successful configuration:

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -143,6 +143,13 @@ Enter the sbin directory of iotdb and start confignode
 
 ```Shell
 ./start-confignode.sh    -d      #The "- d" parameter will start in the background 
+
+# Windows
+# Before version V2.0.4.x
+.\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-confignode.bat
 ```
 If the startup fails, please refer to [Common Questions](#common-questions).
 
@@ -153,6 +160,13 @@ Enter the sbin directory of iotdb and start datanode:
 ```Shell
 cd sbin
 ./start-datanode.sh   -d   #The "- d" parameter will start in the background 
+
+# Windows
+# Before version V2.0.4.x
+.\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\windows\start-datanode.bat
 ```
 
 ### 2.6 Verify Deployment
@@ -161,6 +175,13 @@ Can be executed directly/ Cli startup script in sbin directory:
 
 ```Shell
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
+
+# Windows
+# Before version V2.0.4.x
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x and later versions
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
 After successful startup, the following interface will appear displaying successful installation of IOTDB.

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -142,6 +142,7 @@ Open the DataNode configuration file (./conf/iotdb-system. properties file) and 
 Enter the sbin directory of iotdb and start confignode
 
 ```Shell
+# Unix/OS X
 ./start-confignode.sh    -d      #The "- d" parameter will start in the background 
 
 # Windows
@@ -158,6 +159,7 @@ If the startup fails, please refer to [Common Questions](#common-questions).
 Enter the sbin directory of iotdb and start datanode:
 
 ```Shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #The "- d" parameter will start in the background 
 
@@ -174,6 +176,7 @@ cd sbin
 Can be executed directly/ Cli startup script in sbin directory:
 
 ```Shell
+# Unix/OS X
 ./start-cli.sh  -h  ip(local IP or domain name)  -p  port(6667)
 
 # Windows

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -147,6 +147,7 @@ Set the following parameters in `conf/iotdb-system.properties`. Refer to `conf/i
 Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
+# Unix/OS X
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
 
 # Windows
@@ -164,6 +165,7 @@ Navigate to the `sbin` directory and start ConfigNode:
 Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ````shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
 
 # Windows

--- a/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -148,6 +148,13 @@ Navigate to the `sbin` directory and start ConfigNode:
 
 ```Bash
 ./sbin/start-confignode.sh -d   # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-confignode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-confignode.bat
 ```
 
  If the startup fails, refer to the  [**Common Problem**](#Common Problem) section below for troubleshooting.
@@ -158,6 +165,13 @@ Navigate to the `sbin` directory of IoTDB and start the DataNode:
 
 ````shell
 ./sbin/start-datanode.sh -d    # The "-d" flag starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ````
 
 ### 2.6 Activate Database

--- a/src/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -131,6 +131,7 @@ To ensure the Workbench installation package you obtained is complete and valid,
 2. Restart all nodes. After modifying the monitoring indicator configuration of three nodes, the confignode and datanode services of all nodes can be restarted:
 
     ```shell
+    # Unix/OS X
     ./sbin/stop-standalone.sh      #Stop confignode and datanode first
     ./sbin/start-confignode.sh  -d #Start confignode
     ./sbin/start-datanode.sh  -d   #Start datanode 

--- a/src/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -134,6 +134,17 @@ To ensure the Workbench installation package you obtained is complete and valid,
     ./sbin/stop-standalone.sh      #Stop confignode and datanode first
     ./sbin/start-confignode.sh  -d #Start confignode
     ./sbin/start-datanode.sh  -d   #Start datanode 
+
+    # Windows
+    # Before version V2.0.4.x
+    .\sbin\stop-standalone.bat
+    .\sbin\start-confignode.bat
+    .\sbin\start-datanode.bat
+
+    # V2.0.4.x and later versions
+    .\sbin\windows\stop-standalone.bat
+    .\sbin\windows\start-confignode.bat
+    .\sbin\windows\start-datanode.bat
     ```
 
 3. After restarting, confirm the running status of each node through the client. If the status is Running, it indicates successful configuration:

--- a/src/UserGuide/latest/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/latest/FAQ/Frequently-asked-questions.md
@@ -39,6 +39,16 @@ There are several ways to identify the version of IoTDB that you are using:
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x and later versions
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * Check pom.xml file:
 
 ```
@@ -150,6 +160,16 @@ The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:0
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows startup command examples:
+
+```
+# Before version V2.0.4.x
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x and later versions
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.9 How to handle error `IndexOutOfBoundsException` from `org.apache.ratis.grpc.server.GrpcLogAppender`?

--- a/src/UserGuide/latest/FAQ/Frequently-asked-questions.md
+++ b/src/UserGuide/latest/FAQ/Frequently-asked-questions.md
@@ -30,6 +30,7 @@ There are several ways to identify the version of IoTDB that you are using:
 * Launch IoTDB's Command Line Interface:
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -159,6 +160,7 @@ IoTDB> show timeseries root.fit.d1.*
 The default IoTDB's Cli time display format is readable (e.g. ```1970-01-01T08:00:00.001```), if you want to display time in timestamp type or other readable format, add parameter ```-disableISO8601``` in start command:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/UserGuide/latest/User-Manual/Load-Balance.md
+++ b/src/UserGuide/latest/User-Manual/Load-Balance.md
@@ -169,6 +169,13 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
+
+# Windows
+# Before version V2.0.4.x
+.\sbin\start-datanode.bat
+
+# V2.0.4.x and later versions
+.\sbin\windows\start-datanode.bat
 ```
 
 5. Connect to the original cluster via CLI command for post-scaling verification.
@@ -178,7 +185,11 @@ Navigate to the `sbin`directory under IoTDB and start the datanode:
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
 
   # Windows
+  # Before version V2.0.4.x
   .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x and later versions
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. Execute commands for verification.
@@ -315,7 +326,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x and later
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 **Parameter description:**

--- a/src/UserGuide/latest/User-Manual/Load-Balance.md
+++ b/src/UserGuide/latest/User-Manual/Load-Balance.md
@@ -168,6 +168,7 @@ vim iotdb-system.properties
 Navigate to the `sbin`directory under IoTDB and start the datanode:
 
 ```
+# Unix/OS X
 ./sbin/start-datanode.sh -d    # The "-d" parameter starts the process in the background.
 
 # Windows

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -170,6 +170,7 @@ cd  apache-iotdb-{version}-all-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
@@ -188,6 +189,7 @@ cd sbin
  分别进入iotdb的sbin目录下，依次启动3个datanode节点：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -443,6 +445,7 @@ remove datanode [datanode_id]
          1. 结束所有 ConfigNode 和 DataNode 进程。
 ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -172,6 +172,13 @@ cd  apache-iotdb-{version}-all-bin
 ```shell
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下[常见问题](#常见问题)
@@ -183,6 +190,13 @@ cd sbin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 启动 CLI
@@ -193,8 +207,12 @@ cd sbin
 # Linux或MACOS系统
 ./start-cli.sh -sql_dialect table
 
-# windows系统
-./start-cli.bat -sql_dialect table
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli-table.bat
 ```
 
 ### 3.6 一键启停集群
@@ -382,7 +400,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 说明：在添加DataNode后，随着新的写入到来（以及旧数据过期，如果设置了TTL），集群负载会逐渐向新的DataNode均衡，最终在所有节点上达到存算资源的均衡。
@@ -423,9 +441,16 @@ remove datanode [datanode_id]
         - 清理环境：
 
          1. 结束所有 ConfigNode 和 DataNode 进程。
-        ```Bash
+```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -171,6 +171,7 @@ cd  timechodb-{version}-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
@@ -189,6 +190,7 @@ cd sbin
  分别进入iotdb的sbin目录下，依次启动3个datanode节点：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -519,6 +521,7 @@ remove datanode [datanode_id]
          1. 结束所有 ConfigNode 和 DataNode 进程。
 ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -173,6 +173,13 @@ cd  timechodb-{version}-bin
 ```shell
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下[常见问题](#常见问题)
@@ -184,6 +191,13 @@ cd sbin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 激活数据库
@@ -459,7 +473,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 说明：在添加DataNode后，随着新的写入到来（以及旧数据过期，如果设置了TTL），集群负载会逐渐向新的DataNode均衡，最终在所有节点上达到存算资源的均衡。
@@ -503,9 +517,16 @@ remove datanode [datanode_id]
         - 清理环境：
 
          1. 结束所有 ConfigNode 和 DataNode 进程。
-        ```Bash
+```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -60,6 +60,7 @@
 - 在机器A上创建数据同步流程，即机器A上的数据自动同步到机器B，使用sbin目录下的cli工具连接A上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-1
 
     # Windows
@@ -91,6 +92,7 @@
   - 在机器B上创建数据同步流程，即机器B上的数据自动同步到机器A，使用sbin目录下的cli工具连接B上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-2
 
     # Windows
@@ -163,6 +165,7 @@ show pipes
 - 在机器A的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
@@ -182,6 +185,7 @@ show pipes
 - 在机器B的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -61,6 +61,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-1
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
     ```
 
 - 创建并启动数据同步命令，SQL 如下:
@@ -85,6 +92,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-2
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
     ```
 
     创建并启动pipe，SQL 如下:
@@ -152,6 +166,17 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\windows\stop-standalone.bat
     ```
 
 - 在机器B的执行下列命令：
@@ -160,4 +185,15 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\windows\stop-standalone.bat
     ```

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -56,6 +56,7 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 2. 重启所有节点。修改3个节点的监控指标配置后，可重新启动所有节点的confignode和datanode服务：
 
 ```shell
+# Unix/OS X
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -59,6 +59,17 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\stop-standalone.bat
+.\sbin\start-confignode.bat
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\stop-standalone.bat
+.\sbin\windows\start-confignode.bat
+.\sbin\windows\start-datanode.bat
 ```
 
 3. 重启后，通过客户端确认各节点的运行状态，若状态都为Running，则为配置成功：

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -88,7 +88,7 @@ cd  apache-iotdb-{version}-all-bin
 
 | **配置项**  | **说明**                               | **默认值** | **推荐值**                                       | 备注         |
 | :---------- | :------------------------------------- | :--------- | :----------------------------------------------- | :----------- |
-| MEMORY_SIZE | IoTDB ConfigNode节点可以使用的内存总量 | 根据系统内存自动计算，默认为系统内存的30%         | 可按需填写，填写后系统会根据填写的数值来分配内存 | 修改后保存即可，无需执行；重启服务后生效 |
+| MEMORY_SIZE | IoTDB ConfigNode节点可以使用的内存总量 | 根据系统内存自动计算，默认为系统内存的30%          | 可按需填写，填写后系统会根据填写的数值来分配内存 | 修改后保存即可，无需执行；重启服务后生效 |
 
 - conf/datanode-env.sh（或 .bat）
 
@@ -136,6 +136,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下方[常见问题](#常见问题)。
@@ -146,6 +153,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 ### 2.6 启动 CLI
 
@@ -155,8 +169,12 @@ DataNode 配置
 # Linux或MACOS系统
 ./start-cli.sh -sql_dialect table
 
-# windows系统
-./start-cli.bat -sql_dialect table
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli-table.bat
 ```
 
 ## 3. 常见问题
@@ -170,6 +188,13 @@ DataNode 配置
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -135,6 +135,7 @@ DataNode 配置
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -152,6 +153,7 @@ DataNode 配置
  进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows
@@ -187,6 +189,7 @@ DataNode 配置
          1. 结束所有 ConfigNode 和 DataNode 进程。
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -136,6 +136,7 @@ DataNode 配置
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -153,6 +154,7 @@ DataNode 配置
  进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows
@@ -251,6 +253,7 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
          1. 结束所有 ConfigNode 和 DataNode 进程。
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -137,6 +137,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下方[常见问题](#常见问题)。
@@ -147,6 +154,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 激活数据库
@@ -238,6 +252,13 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
@@ -32,6 +32,7 @@
 * 启动 IoTDB 的命令行界面：
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -112,6 +113,7 @@ Readme.md
 IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T08:00:00.001```)，如果您想显示是时间戳或者其他可读格式，请在启动命令上添加参数```-disableISO8601```:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/zh/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/Master/Table/FAQ/Frequently-asked-questions.md
@@ -41,6 +41,16 @@
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x 版本及之后
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * 检查 pom.xml 文件：
 
 ```
@@ -103,6 +113,16 @@ IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x 版本及之后
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.6 怎么处理来自`org.apache.ratis.grpc.server.GrpcLogAppender`的`IndexOutOfBoundsException`？

--- a/src/zh/UserGuide/Master/Table/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/Master/Table/User-Manual/Load-Balance.md
@@ -165,6 +165,13 @@ vim iotdb-system.properies
 
 ```Shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 5. 通过CLI命令连接原集群，进行扩容后验证
@@ -173,8 +180,12 @@ vim iotdb-system.properies
 # Linux或MACOS系统
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
   
-  # windows系统
-  ./apache-iotdb-{version}-bin/sbin/start-cli.bat
+  # Windows
+  # V2.0.4.x 版本之前
+  .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x 版本及之后
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. 执行命令进行验证
@@ -314,7 +325,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：

--- a/src/zh/UserGuide/Master/Table/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/Master/Table/User-Manual/Load-Balance.md
@@ -164,6 +164,7 @@ vim iotdb-system.properies
 进入iotdb的sbin目录下，启动datanode：
 
 ```Shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -171,6 +171,13 @@ cd  apache-iotdb-{version}-all-bin
 ```Bash
 cd sbin
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 如果启动失败，请参考[常见问题](#常见问题)。
 
@@ -181,6 +188,13 @@ cd sbin
 ```Bash
 cd sbin
 ./start-datanode.sh   -d   #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 验证部署
@@ -189,6 +203,13 @@ cd sbin
 
 ```Plain
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
    成功启动后，出现如下界面显示IOTDB安装成功。
@@ -397,7 +418,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：
@@ -460,9 +481,16 @@ remove datanode [datanode_id]
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -169,6 +169,7 @@ cd  apache-iotdb-{version}-all-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
 
@@ -186,6 +187,7 @@ cd sbin
  分别进入iotdb的`sbin`目录下，依次启动3个datanode节点：
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #“-d”参数将在后台进行启动 
 
@@ -202,6 +204,7 @@ cd sbin
 可直接执行`./sbin`目录下的Cli启动脚本：
 
 ```Plain
+# Unix/OS X
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
 
 # Windows
@@ -483,6 +486,7 @@ remove datanode [datanode_id]
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -172,6 +172,13 @@ cd  iotdb-enterprise-{version}-bin
 ```shell
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下[常见问题](#常见问题)
@@ -183,6 +190,13 @@ cd sbin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 激活数据库
@@ -474,7 +488,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：
@@ -542,9 +556,16 @@ remove datanode [datanode_id]
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -170,6 +170,7 @@ cd  iotdb-enterprise-{version}-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
@@ -188,6 +189,7 @@ cd sbin
 分别进入iotdb的sbin目录下，依次启动3个datanode节点：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -558,6 +560,7 @@ remove datanode [datanode_id]
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -60,6 +60,7 @@
 - 在机器A上创建数据同步流程，即机器A上的数据自动同步到机器B，使用sbin目录下的cli工具连接A上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-1
 
     # Windows
@@ -91,6 +92,7 @@
   - 在机器B上创建数据同步流程，即机器B上的数据自动同步到机器A，使用sbin目录下的cli工具连接B上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-2
 
     # Windows
@@ -163,6 +165,7 @@ show pipes
 - 在机器A的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
@@ -182,6 +185,7 @@ show pipes
 - 在机器B的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -61,6 +61,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-1
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
     ```
 
 - 创建并启动数据同步命令，SQL 如下:
@@ -85,6 +92,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-2
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
     ```
 
     创建并启动pipe，SQL 如下:
@@ -152,6 +166,17 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\windows\stop-standalone.bat
     ```
 
 - 在机器B的执行下列命令：
@@ -160,4 +185,15 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\windows\stop-standalone.bat
     ```

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -61,6 +61,17 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\stop-standalone.bat
+.\sbin\start-confignode.bat
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\stop-standalone.bat
+.\sbin\windows\start-confignode.bat
+.\sbin\windows\start-datanode.bat
 ```
 
 3. 重启后，通过客户端确认各节点的运行状态，若状态都为Running，则为配置成功：
@@ -225,8 +236,8 @@ cd grafana-*
   - Unseq：乱序 TsFile 数量
   - WAL：WAL 文件数量
   - Cross-Temp：跨空间合并 temp 文件数量
-  - Tnner-Seq-Temp：顺序空间内合并 temp 文件数量
-  - Innser-Unseq-Temp：乱序空间内合并 temp 文件数量
+  - Inner-Seq-Temp：顺序空间内合并 temp 文件数量
+  - Innsr-Unseq-Temp：乱序空间内合并 temp 文件数量
   - Mods：墓碑文件数量
 - Open File Handles：系统打开的文件句柄数量
 - File Size：IoTDB 相关文件的大小。各子项分别是对应文件的大小。

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -58,6 +58,7 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 2. 重启所有节点。修改3个节点的监控指标配置后，可重新启动所有节点的confignode和datanode服务：
 
 ```shell
+# Unix/OS X
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -139,6 +139,7 @@ cd  apache-iotdb-{version}-all-bin
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -155,6 +156,7 @@ cd  apache-iotdb-{version}-all-bin
  进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -171,6 +173,7 @@ cd sbin
 可直接执行 ./sbin 目录下的 Cli 启动脚本：
 
 ```shell
+# Unix/OS X
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
 
 # Windows
@@ -207,6 +210,7 @@ cd sbin
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -140,6 +140,13 @@ cd  apache-iotdb-{version}-all-bin
 
 ```shell
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 如果启动失败，请参考[常见问题](#常见问题)。
 
@@ -150,6 +157,13 @@ cd  apache-iotdb-{version}-all-bin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 2.6 验证部署
@@ -158,6 +172,13 @@ cd sbin
 
 ```shell
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
    成功启动后，出现如下界面显示IoTDB安装成功。
@@ -184,9 +205,16 @@ cd sbin
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -143,6 +143,7 @@ cd  iotdb-enterprise-{version}-bin
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -160,6 +161,7 @@ cd  iotdb-enterprise-{version}-bin
 进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows
@@ -263,6 +265,7 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -144,6 +144,13 @@ cd  iotdb-enterprise-{version}-bin
 
 ```shell
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下方[常见问题](#常见问题)。
@@ -154,6 +161,13 @@ cd  iotdb-enterprise-{version}-bin
 
 ```shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 激活数据库
@@ -247,9 +261,16 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -130,6 +130,7 @@
 2. 重启所有节点。修改3个节点的监控指标配置后，可重新启动所有节点的confignode和datanode服务：
 
     ```shell
+    # Unix/OS X
     ./sbin/stop-standalone.sh      #先停止confignode和datanode
     ./sbin/start-confignode.sh  -d #启动confignode
     ./sbin/start-datanode.sh  -d   #启动datanode 

--- a/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/zh/UserGuide/Master/Tree/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -133,6 +133,17 @@
     ./sbin/stop-standalone.sh      #先停止confignode和datanode
     ./sbin/start-confignode.sh  -d #启动confignode
     ./sbin/start-datanode.sh  -d   #启动datanode 
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\stop-standalone.bat
+    .\sbin\start-confignode.bat
+    .\sbin\start-datanode.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\stop-standalone.bat
+    .\sbin\windows\start-confignode.bat
+    .\sbin\windows\start-datanode.bat
     ```
 
 3. 重启后，通过客户端确认各节点的运行状态，若状态都为Running，则为配置成功：

--- a/src/zh/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
@@ -41,6 +41,16 @@
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x 版本及之后
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * 检查 pom.xml 文件：
 
 ```
@@ -152,6 +162,16 @@ IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x 版本及之后
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.9 怎么处理来自`org.apache.ratis.grpc.server.GrpcLogAppender`的`IndexOutOfBoundsException`？

--- a/src/zh/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/Master/Tree/FAQ/Frequently-asked-questions.md
@@ -32,6 +32,7 @@
 * 启动 IoTDB 的命令行界面：
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -161,6 +162,7 @@ IoTDB> show timeseries root.fit.d1.*
 IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T08:00:00.001```)，如果您想显示是时间戳或者其他可读格式，请在启动命令上添加参数```-disableISO8601```:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/zh/UserGuide/Master/Tree/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/Master/Tree/User-Manual/Load-Balance.md
@@ -164,6 +164,7 @@ vim iotdb-system.properies
 进入iotdb的sbin目录下，启动datanode：
 
 ```Shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows

--- a/src/zh/UserGuide/Master/Tree/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/Master/Tree/User-Manual/Load-Balance.md
@@ -165,6 +165,13 @@ vim iotdb-system.properies
 
 ```Shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 5. 通过CLI命令连接原集群，进行扩容后验证
@@ -173,8 +180,12 @@ vim iotdb-system.properies
 # Linux或MACOS系统
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
   
-  # windows系统
-  ./apache-iotdb-{version}-bin/sbin/start-cli.bat
+  # Windows
+  # V2.0.4.x 版本之前
+  .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x 版本及之后
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. 执行命令进行验证
@@ -315,7 +326,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -170,6 +170,7 @@ cd  apache-iotdb-{version}-all-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
@@ -188,6 +189,7 @@ cd sbin
  分别进入iotdb的sbin目录下，依次启动3个datanode节点：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -443,6 +445,7 @@ remove datanode [datanode_id]
          1. 结束所有 ConfigNode 和 DataNode 进程。
 ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -172,6 +172,13 @@ cd  apache-iotdb-{version}-all-bin
 ```shell
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下[常见问题](#常见问题)
@@ -183,6 +190,13 @@ cd sbin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 启动 CLI
@@ -193,8 +207,12 @@ cd sbin
 # Linux或MACOS系统
 ./start-cli.sh -sql_dialect table
 
-# windows系统
-./start-cli.bat -sql_dialect table
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli-table.bat
 ```
 
 ### 3.6 一键启停集群
@@ -382,7 +400,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 说明：在添加DataNode后，随着新的写入到来（以及旧数据过期，如果设置了TTL），集群负载会逐渐向新的DataNode均衡，最终在所有节点上达到存算资源的均衡。
@@ -423,9 +441,16 @@ remove datanode [datanode_id]
         - 清理环境：
 
          1. 结束所有 ConfigNode 和 DataNode 进程。
-        ```Bash
+```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -171,6 +171,7 @@ cd  timechodb-{version}-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
@@ -189,6 +190,7 @@ cd sbin
  分别进入iotdb的sbin目录下，依次启动3个datanode节点：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -519,6 +521,7 @@ remove datanode [datanode_id]
          1. 结束所有 ConfigNode 和 DataNode 进程。
 ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -173,6 +173,13 @@ cd  timechodb-{version}-bin
 ```shell
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下[常见问题](#常见问题)
@@ -184,6 +191,13 @@ cd sbin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 激活数据库
@@ -459,7 +473,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 说明：在添加DataNode后，随着新的写入到来（以及旧数据过期，如果设置了TTL），集群负载会逐渐向新的DataNode均衡，最终在所有节点上达到存算资源的均衡。
@@ -503,9 +517,16 @@ remove datanode [datanode_id]
         - 清理环境：
 
          1. 结束所有 ConfigNode 和 DataNode 进程。
-        ```Bash
+```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -60,6 +60,7 @@
 - 在机器A上创建数据同步流程，即机器A上的数据自动同步到机器B，使用sbin目录下的cli工具连接A上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-1
 
     # Windows
@@ -91,6 +92,7 @@
   - 在机器B上创建数据同步流程，即机器B上的数据自动同步到机器A，使用sbin目录下的cli工具连接B上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-2
 
     # Windows
@@ -163,6 +165,7 @@ show pipes
 - 在机器A的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
@@ -182,6 +185,7 @@ show pipes
 - 在机器B的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -61,6 +61,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-1
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
     ```
 
 - 创建并启动数据同步命令，SQL 如下:
@@ -85,6 +92,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-2
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
     ```
 
     创建并启动pipe，SQL 如下:
@@ -152,6 +166,17 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\windows\stop-standalone.bat
     ```
 
 - 在机器B的执行下列命令：
@@ -160,4 +185,15 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\windows\stop-standalone.bat
     ```

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -56,6 +56,7 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 2. 重启所有节点。修改3个节点的监控指标配置后，可重新启动所有节点的confignode和datanode服务：
 
 ```shell
+# Unix/OS X
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -59,6 +59,17 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\stop-standalone.bat
+.\sbin\start-confignode.bat
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\stop-standalone.bat
+.\sbin\windows\start-confignode.bat
+.\sbin\windows\start-datanode.bat
 ```
 
 3. 重启后，通过客户端确认各节点的运行状态，若状态都为Running，则为配置成功：

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -136,6 +136,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下方[常见问题](#常见问题)。
@@ -146,6 +153,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 ### 2.6 启动 CLI
 
@@ -155,8 +169,12 @@ DataNode 配置
 # Linux或MACOS系统
 ./start-cli.sh -sql_dialect table
 
-# windows系统
-./start-cli.bat -sql_dialect table
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -sql_dialect table
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli-table.bat
 ```
 
 ## 3. 常见问题
@@ -170,6 +188,13 @@ DataNode 配置
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -135,6 +135,7 @@ DataNode 配置
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -152,6 +153,7 @@ DataNode 配置
  进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows
@@ -187,6 +189,7 @@ DataNode 配置
          1. 结束所有 ConfigNode 和 DataNode 进程。
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -136,6 +136,7 @@ DataNode 配置
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -153,6 +154,7 @@ DataNode 配置
  进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows
@@ -251,6 +253,7 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
          1. 结束所有 ConfigNode 和 DataNode 进程。
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
+             # Unix/OS X
              sbin/stop-standalone.sh
 
              # Windows

--- a/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest-Table/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -137,6 +137,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下方[常见问题](#常见问题)。
@@ -147,6 +154,13 @@ DataNode 配置
 
 ```shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 激活数据库
@@ -238,6 +252,13 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
         ```Bash
              # 1. 停止 ConfigNode 和 DataNode 服务
              sbin/stop-standalone.sh
+
+             # Windows
+             # V2.0.4.x 版本之前
+             sbin\stop-standalone.bat
+
+             # V2.0.4.x 版本及之后
+             sbin\windows\stop-standalone.bat
             
              # 2. 检查是否还有进程残留
              jps

--- a/src/zh/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
@@ -32,6 +32,7 @@
 * 启动 IoTDB 的命令行界面：
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -112,6 +113,7 @@ Readme.md
 IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T08:00:00.001```)，如果您想显示是时间戳或者其他可读格式，请在启动命令上添加参数```-disableISO8601```:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/zh/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/latest-Table/FAQ/Frequently-asked-questions.md
@@ -41,6 +41,16 @@
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x 版本及之后
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * 检查 pom.xml 文件：
 
 ```
@@ -103,6 +113,16 @@ IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x 版本及之后
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.6 怎么处理来自`org.apache.ratis.grpc.server.GrpcLogAppender`的`IndexOutOfBoundsException`？

--- a/src/zh/UserGuide/latest-Table/User-Manual/Data-Security.md
+++ b/src/zh/UserGuide/latest-Table/User-Manual/Data-Security.md
@@ -209,7 +209,15 @@ try (Connection connection =
 ### 2.6 CLI
 
 ```SQL
+# Linux / MacOS
 ./start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -usessl true -ts /Users/keystore/.truststore -tpw 123456
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -usessl true -ts C:\Users\keystore\.truststore -tpw 123456
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -usessl true -ts C:\Users\keystore\.truststore -tpw 123456
 ```
 
 ### 2.7 SSL证书生成方式

--- a/src/zh/UserGuide/latest-Table/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/latest-Table/User-Manual/Load-Balance.md
@@ -165,6 +165,13 @@ vim iotdb-system.properies
 
 ```Shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 5. 通过CLI命令连接原集群，进行扩容后验证
@@ -173,8 +180,12 @@ vim iotdb-system.properies
 # Linux或MACOS系统
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
   
-  # windows系统
-  ./apache-iotdb-{version}-bin/sbin/start-cli.bat
+  # Windows
+  # V2.0.4.x 版本之前
+  .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x 版本及之后
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. 执行命令进行验证
@@ -314,7 +325,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：

--- a/src/zh/UserGuide/latest-Table/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/latest-Table/User-Manual/Load-Balance.md
@@ -164,6 +164,7 @@ vim iotdb-system.properies
 进入iotdb的sbin目录下，启动datanode：
 
 ```Shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -171,6 +171,13 @@ cd  apache-iotdb-{version}-all-bin
 ```Bash
 cd sbin
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 如果启动失败，请参考[常见问题](#常见问题)。
 
@@ -181,6 +188,13 @@ cd sbin
 ```Bash
 cd sbin
 ./start-datanode.sh   -d   #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 验证部署
@@ -189,6 +203,13 @@ cd sbin
 
 ```Plain
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
    成功启动后，出现如下界面显示IOTDB安装成功。
@@ -397,7 +418,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：
@@ -460,9 +481,16 @@ remove datanode [datanode_id]
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_apache.md
@@ -169,6 +169,7 @@ cd  apache-iotdb-{version}-all-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
 
@@ -186,6 +187,7 @@ cd sbin
  分别进入iotdb的`sbin`目录下，依次启动3个datanode节点：
 
 ```Bash
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #“-d”参数将在后台进行启动 
 
@@ -202,6 +204,7 @@ cd sbin
 可直接执行`./sbin`目录下的Cli启动脚本：
 
 ```Plain
+# Unix/OS X
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
 
 # Windows
@@ -483,6 +486,7 @@ remove datanode [datanode_id]
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -172,6 +172,13 @@ cd  iotdb-enterprise-{version}-bin
 ```shell
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下[常见问题](#常见问题)
@@ -183,6 +190,13 @@ cd sbin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 3.5 激活数据库
@@ -474,7 +488,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：
@@ -542,9 +556,16 @@ remove datanode [datanode_id]
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Cluster-Deployment_timecho.md
@@ -170,6 +170,7 @@ cd  iotdb-enterprise-{version}-bin
 先启动第一个iotdb-1的confignode, 保证种子confignode节点先启动，然后依次启动第2和第3个confignode节点
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
@@ -188,6 +189,7 @@ cd sbin
 分别进入iotdb的sbin目录下，依次启动3个datanode节点：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -558,6 +560,7 @@ remove datanode [datanode_id]
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -60,6 +60,7 @@
 - 在机器A上创建数据同步流程，即机器A上的数据自动同步到机器B，使用sbin目录下的cli工具连接A上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-1
 
     # Windows
@@ -91,6 +92,7 @@
   - 在机器B上创建数据同步流程，即机器B上的数据自动同步到机器A，使用sbin目录下的cli工具连接B上的IoTDB数据库：
 
     ```Bash
+    # Unix/OS X
     ./sbin/start-cli.sh  -h iotdb-2
 
     # Windows
@@ -163,6 +165,7 @@ show pipes
 - 在机器A的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
@@ -182,6 +185,7 @@ show pipes
 - 在机器B的执行下列命令：
 
     ```SQL
+    # Unix/OS X
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Dual-Active-Deployment_timecho.md
@@ -61,6 +61,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-1
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
     ```
 
 - 创建并启动数据同步命令，SQL 如下:
@@ -85,6 +92,13 @@
 
     ```Bash
     ./sbin/start-cli.sh  -h iotdb-2
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
     ```
 
     创建并启动pipe，SQL 如下:
@@ -152,6 +166,17 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-1  #登录cli
     IoTDB> stop pipe AB             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-1
+    IoTDB> stop pipe AB
+    .\sbin\windows\stop-standalone.bat
     ```
 
 - 在机器B的执行下列命令：
@@ -160,4 +185,15 @@ show pipes
     ./sbin/start-cli.sh -h iotdb-2  #登录cli
     IoTDB> stop pipe BA             #停止数据同步流程
     ./sbin/stop-standalone.sh       #停止数据库服务
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\stop-standalone.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\start-cli.bat -h iotdb-2
+    IoTDB> stop pipe BA
+    .\sbin\windows\stop-standalone.bat
     ```

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -58,6 +58,7 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 2. 重启所有节点。修改3个节点的监控指标配置后，可重新启动所有节点的confignode和datanode服务：
 
 ```shell
+# Unix/OS X
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Monitoring-panel-deployment.md
@@ -61,6 +61,17 @@ IoTDB配套监控面板是IoTDB企业版配套工具之一。它旨在解决IoTD
 ./sbin/stop-standalone.sh      #先停止confignode和datanode
 ./sbin/start-confignode.sh  -d #启动confignode
 ./sbin/start-datanode.sh  -d   #启动datanode 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\stop-standalone.bat
+.\sbin\start-confignode.bat
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\stop-standalone.bat
+.\sbin\windows\start-confignode.bat
+.\sbin\windows\start-datanode.bat
 ```
 
 3. 重启后，通过客户端确认各节点的运行状态，若状态都为Running，则为配置成功：

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -139,6 +139,7 @@ cd  apache-iotdb-{version}-all-bin
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -155,6 +156,7 @@ cd  apache-iotdb-{version}-all-bin
  进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
 
@@ -171,6 +173,7 @@ cd sbin
 可直接执行 ./sbin 目录下的 Cli 启动脚本：
 
 ```shell
+# Unix/OS X
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
 
 # Windows
@@ -207,6 +210,7 @@ cd sbin
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_apache.md
@@ -140,6 +140,13 @@ cd  apache-iotdb-{version}-all-bin
 
 ```shell
 ./start-confignode.sh    -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-confignode.bat
 ```
 如果启动失败，请参考[常见问题](#常见问题)。
 
@@ -150,6 +157,13 @@ cd  apache-iotdb-{version}-all-bin
 ```shell
 cd sbin
 ./start-datanode.sh   -d   #-d参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\windows\start-datanode.bat
 ```
 
 ### 2.6 验证部署
@@ -158,6 +172,13 @@ cd sbin
 
 ```shell
 ./start-cli.sh  -h  ip(本机ip或域名)  -p  端口号(6667)
+
+# Windows
+# V2.0.4.x 版本之前
+.\start-cli.bat -h ip -p 6667
+
+# V2.0.4.x 版本及之后
+.\windows\start-cli.bat -h ip -p 6667
 ```
 
    成功启动后，出现如下界面显示IoTDB安装成功。
@@ -184,9 +205,16 @@ cd sbin
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -143,6 +143,7 @@ cd  iotdb-enterprise-{version}-bin
 进入iotdb的sbin目录下，启动confignode
 
 ```shell
+# Unix/OS X
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
 
 # Windows
@@ -160,6 +161,7 @@ cd  iotdb-enterprise-{version}-bin
 进入iotdb的sbin目录下，启动datanode：
 
 ```shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows
@@ -263,6 +265,7 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
    
 ```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
+        # Unix/OS X
         sbin/stop-standalone.sh
 
         # Windows

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/Stand-Alone-Deployment_timecho.md
@@ -144,6 +144,13 @@ cd  iotdb-enterprise-{version}-bin
 
 ```shell
 ./sbin/start-confignode.sh -d      #“-d”参数将在后台进行启动 
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-confignode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-confignode.bat
 ```
 
 如果启动失败，请参考下方[常见问题](#常见问题)。
@@ -154,6 +161,13 @@ cd  iotdb-enterprise-{version}-bin
 
 ```shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 ### 2.6 激活数据库
@@ -247,9 +261,16 @@ IoTDB> activate '01-D4EYQGPZ-EAUJJODW-NUKRDR6F-TUQS3B75-EDZFLK3A-6BOKJFFZ-ALDHOM
 
     a. 结束所有 ConfigNode 和 DataNode 进程。
    
-    ```Bash
+```Bash
         # 1. 停止 ConfigNode 和 DataNode 服务
         sbin/stop-standalone.sh
+
+        # Windows
+        # V2.0.4.x 版本之前
+        sbin\stop-standalone.bat
+
+        # V2.0.4.x 版本及之后
+        sbin\windows\stop-standalone.bat
 
         # 2. 检查是否还有进程残留
         jps

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -130,6 +130,7 @@
 2. 重启所有节点。修改3个节点的监控指标配置后，可重新启动所有节点的confignode和datanode服务：
 
     ```shell
+    # Unix/OS X
     ./sbin/stop-standalone.sh      #先停止confignode和datanode
     ./sbin/start-confignode.sh  -d #启动confignode
     ./sbin/start-datanode.sh  -d   #启动datanode 

--- a/src/zh/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
+++ b/src/zh/UserGuide/latest/Deployment-and-Maintenance/workbench-deployment_timecho.md
@@ -133,6 +133,17 @@
     ./sbin/stop-standalone.sh      #先停止confignode和datanode
     ./sbin/start-confignode.sh  -d #启动confignode
     ./sbin/start-datanode.sh  -d   #启动datanode 
+
+    # Windows
+    # V2.0.4.x 版本之前
+    .\sbin\stop-standalone.bat
+    .\sbin\start-confignode.bat
+    .\sbin\start-datanode.bat
+
+    # V2.0.4.x 版本及之后
+    .\sbin\windows\stop-standalone.bat
+    .\sbin\windows\start-confignode.bat
+    .\sbin\windows\start-datanode.bat
     ```
 
 3. 重启后，通过客户端确认各节点的运行状态，若状态都为Running，则为配置成功：

--- a/src/zh/UserGuide/latest/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/latest/FAQ/Frequently-asked-questions.md
@@ -41,6 +41,16 @@
 |_____|'.__.' |_____|  |______.'|_______/  version x.x.x
 ```
 
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> .\sbin\start-cli.bat -p 6667 -pw root -u root -h localhost
+
+# V2.0.4.x 版本及之后
+> .\sbin\windows\start-cli.bat -p 6667 -pw root -u root -h localhost
+```
+
 * 检查 pom.xml 文件：
 
 ```
@@ -152,6 +162,16 @@ IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T
 
 ```
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+```
+
+Windows 系统启动命令示例：
+
+```
+# V2.0.4.x 版本之前
+> %IOTDB_CLI_HOME%\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
+
+# V2.0.4.x 版本及之后
+> %IOTDB_CLI_HOME%\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 
 ### 1.9 怎么处理来自`org.apache.ratis.grpc.server.GrpcLogAppender`的`IndexOutOfBoundsException`？

--- a/src/zh/UserGuide/latest/FAQ/Frequently-asked-questions.md
+++ b/src/zh/UserGuide/latest/FAQ/Frequently-asked-questions.md
@@ -32,6 +32,7 @@
 * 启动 IoTDB 的命令行界面：
 
 ```
+# Unix/OS X
 > ./start-cli.sh -p 6667 -pw root -u root -h localhost
  _____       _________  ______   ______    
 |_   _|     |  _   _  ||_   _ `.|_   _ \   
@@ -161,6 +162,7 @@ IoTDB> show timeseries root.fit.d1.*
 IoTDB 客户端默认显示的时间是人类可读的（比如：```1970-01-01T08:00:00.001```)，如果您想显示是时间戳或者其他可读格式，请在启动命令上添加参数```-disableISO8601```:
 
 ```
+# Unix/OS X
 > $IOTDB_CLI_HOME/sbin/start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -disableISO8601
 ```
 

--- a/src/zh/UserGuide/latest/User-Manual/Data-Security.md
+++ b/src/zh/UserGuide/latest/User-Manual/Data-Security.md
@@ -209,7 +209,15 @@ try (Connection connection =
 ### 2.6 CLI
 
 ```SQL
+# Linux / MacOS
 ./start-cli.sh -h 127.0.0.1 -p 6667 -u root -pw root -usessl true -ts /Users/keystore/.truststore -tpw 123456
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -usessl true -ts C:\Users\keystore\.truststore -tpw 123456
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-cli.bat -h 127.0.0.1 -p 6667 -u root -pw root -usessl true -ts C:\Users\keystore\.truststore -tpw 123456
 ```
 
 ### 2.7 SSL证书生成方式

--- a/src/zh/UserGuide/latest/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/latest/User-Manual/Load-Balance.md
@@ -164,6 +164,7 @@ vim iotdb-system.properies
 进入iotdb的sbin目录下，启动datanode：
 
 ```Shell
+# Unix/OS X
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
 
 # Windows

--- a/src/zh/UserGuide/latest/User-Manual/Load-Balance.md
+++ b/src/zh/UserGuide/latest/User-Manual/Load-Balance.md
@@ -165,6 +165,13 @@ vim iotdb-system.properies
 
 ```Shell
 ./sbin/start-datanode.sh -d    #“-d”参数将在后台进行启动
+
+# Windows
+# V2.0.4.x 版本之前
+.\sbin\start-datanode.bat
+
+# V2.0.4.x 版本及之后
+.\sbin\windows\start-datanode.bat
 ```
 
 5. 通过CLI命令连接原集群，进行扩容后验证
@@ -173,8 +180,12 @@ vim iotdb-system.properies
 # Linux或MACOS系统
   ./apache-iotdb-{version}-bin/sbin/start-cli.sh
   
-  # windows系统
-  ./apache-iotdb-{version}-bin/sbin/start-cli.bat
+  # Windows
+  # V2.0.4.x 版本之前
+  .\apache-iotdb-{version}-bin\sbin\start-cli.bat
+
+  # V2.0.4.x 版本及之后
+  .\apache-iotdb-{version}-bin\sbin\windows\start-cli.bat
 ```
 
 6. 执行命令进行验证
@@ -315,7 +326,7 @@ sbin/start-datanode.sh
 sbin\start-datanode.bat
 
 # V2.0.4.x 版本及之后     
-tools\windows\start-datanode.bat
+sbin\windows\start-datanode.bat
 ```
 
 参数介绍：


### PR DESCRIPTION
## Summary
- Add Windows command examples for deployment and operations-flow docs.
- Sync latest, latest-Table, Master Tree/Table, and Chinese/English docs.
- Label existing Unix command examples with `# Unix/OS X` where Windows examples were added.

## Checks
- `git diff --check`