### PR TITLE
Remove UDF libraries sidebar entries

### DIFF
--- a/src/.vuepress/sidebar/V1.3.x/en.ts
+++ b/src/.vuepress/sidebar/V1.3.x/en.ts
@@ -285,7 +285,6 @@ export const enSidebar = {
           text: 'Functions and Operators',
           collapsible: true,
           children: [
-            { text: 'UDF Libraries', link: 'UDF-Libraries_apache' },
             {
               text: 'Operator and Expression',
               link: 'Operator-and-Expression',

--- a/src/.vuepress/sidebar/V1.3.x/zh.ts
+++ b/src/.vuepress/sidebar/V1.3.x/zh.ts
@@ -276,7 +276,6 @@ export const zhSidebar = {
           text: '函数与运算符',
           collapsible: true,
           children: [
-            { text: 'UDF函数库', link: 'UDF-Libraries_apache' },
             { text: '函数与运算符', link: 'Operator-and-Expression' },
             { text: '内置函数与表达式', link: 'Function-and-Expression' },
           ],

--- a/src/.vuepress/sidebar/V2.0.x/en-Tree.ts
+++ b/src/.vuepress/sidebar/V2.0.x/en-Tree.ts
@@ -281,7 +281,6 @@ export const enSidebar = {
           text: 'Functions and Operators',
           collapsible: true,
           children: [
-            { text: 'UDF Libraries', link: 'UDF-Libraries_apache' },
             {
               text: 'Operator and Expression',
               link: 'Operator-and-Expression',

--- a/src/.vuepress/sidebar/V2.0.x/zh-Tree.ts
+++ b/src/.vuepress/sidebar/V2.0.x/zh-Tree.ts
@@ -272,7 +272,6 @@ export const zhSidebar = {
           text: '函数与运算符',
           collapsible: true,
           children: [
-            { text: 'UDF函数库', link: 'UDF-Libraries_apache' },
             { text: '函数与运算符', link: 'Operator-and-Expression' },
             { text: '内置函数与表达式', link: 'Function-and-Expression' },
           ],


### PR DESCRIPTION
## Summary
- Remove UDF Libraries sidebar entries from V1.3.x English/Chinese sidebars
- Remove UDF Libraries sidebar entries from V2.0.x English/Chinese tree sidebars

## Test
- `node --max_old_space_size=8192 ./node_modules/vuepress/bin/vuepress.js build src`