### PR TITLE
Update community onboarding documentation

### DIFF
--- a/src/Community/About-the-Community.md
+++ b/src/Community/About-the-Community.md
@@ -98,11 +98,10 @@ Referring to the Apache Software Foundation's community philosophy, our communit
 
 Becoming a Contributor requires no election: anyone who makes a valid contribution to the project is a Contributor. The following is a recommended path to start contributing to IoTDB from scratch.
 
-#### Step 1: Set up your development accounts
+#### Step 1: Join the community discussion
 
-- Create a Jira account: <https://issues.apache.org/jira/projects/IOTDB/issues>, used to claim development tasks (issues).
-- Create a Confluence account: <https://cwiki.apache.org/confluence/display/IOTDB/Home>, used to read and write design documents.
-- Once your accounts are ready, send an introduction email to the developer mailing list <dev@iotdb.apache.org> with your **Jira ID** and **Confluence ID**, and the community PMC will grant you the corresponding permissions.
+- Subscribe to the developer mailing list <dev@iotdb.apache.org>. The mailing list is the official communication channel of the Apache community, where development plans, technical discussions, and requests for help all take place. See [Communication Channels](https://iotdb.apache.org/Community/Communication-Channels.html) for how to subscribe.
+- When participating for the first time, feel free to send an email to introduce yourself. If you run into any problems during development, you can start a discussion on the mailing list.
 
 #### Step 2: Get the code running
 
@@ -110,19 +109,20 @@ Becoming a Contributor requires no election: anyone who makes a valid contributi
   - [Apache IoTDB README](https://github.com/apache/iotdb/blob/master/README.md) (environment requirements, building, and starting DataNode/CLI with breakpoint debugging in IDEA)
   - [Development Guide](https://iotdb.apache.org/Community/Development-Guide.html) (contribution workflow, code formatting, PR conventions, etc.)
 - To get familiar with IoTDB as a user first, see:
-  - [IoTDB download and installation](../UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.md)
+  - [IoTDB download and installation](https://iotdb.apache.org/UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.html)
   - [IoTDB Quick Start Guide](https://iotdb.apache.org/UserGuide/latest/QuickStart/QuickStart_apache.html)
   - [Data Schema and Concepts](https://iotdb.apache.org/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html)
   - [Java Native API](https://iotdb.apache.org/UserGuide/latest/API/Programming-Java-Native-API.html)
 
 #### Step 3: Understand the internal design
 
-- [IoTDB Design Documentation (Confluence)](https://cwiki.apache.org/confluence/display/IOTDB/Home)
+- The design and implementation of IoTDB mainly live in the source code; reading it together with the [README](https://github.com/apache/iotdb/blob/master/README.md) is recommended.
+- If you have questions about the design, feel free to raise them on the mailing list <dev@iotdb.apache.org>, where community members will join the discussion.
 
 #### Step 4: Pick a task and start contributing
 
-- Browse and claim issues on Jira: <https://issues.apache.org/jira/projects/IOTDB/issues>. Newcomers are encouraged to start with issues labeled newbie / good first issue.
-- For the full contribution workflow (claim an issue → submit a PR → review → merge), see the [Development Guide](https://iotdb.apache.org/Community/Development-Guide.html).
+- You can look for tasks that interest you on [GitHub Issues](https://github.com/apache/iotdb/issues) or [Jira](https://issues.apache.org/jira/projects/IOTDB/issues), or describe what you would like to work on via the mailing list. Newcomers are encouraged to start with issues labeled newbie / good first issue.
+- For the full contribution workflow (submit a PR → review → merge), see the [Development Guide](https://iotdb.apache.org/Community/Development-Guide.html).
 - If you run into problems, feel free to ask via the mailing list or the channels listed in [Communication Channels](https://iotdb.apache.org/Community/Communication-Channels.html).
 
 ## Code of Conduct in the Apache Community

--- a/src/Community/About-the-Community.md
+++ b/src/Community/About-the-Community.md
@@ -96,22 +96,34 @@ Referring to the Apache Software Foundation's community philosophy, our communit
 
 ### Contributor
 
-- Set up a development platform account:
-  - Create a Jira account: [https://issues.apache.org/jira/projects/IOTDB/issues](https://issues.apache.org/jira/projects/IOTDB/issues) to claim an issue.
-  - Create a Confluence account: [https://cwiki.apache.org/confluence/display/IOTDB/Home](https://cwiki.apache.org/confluence/display/IOTDB/Home). This will be used to write the design documentation.
-    Once created, send an email to the mailing list with **Introduction** and **Jira ID** and **Confluence ID** and the community PMC will add permissions to the account.
-- Long Term Matters:
-  - Learn how to debug IoTDB
-    - [How to debug IoTDB server](https://my.oschina.net/u/3664598/blog/4500279)
-  - Understand the basics of using IoTDB
-    - [IoTDB download and installation](../UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.md)
-    - [IoTDB Quick Start Guide](https://iotdb.apache.org/UserGuide/latest/QuickStart/QuickStart_apache.html)
-    - [Data Schema and Concepts](https://iotdb.apache.org/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html)
-    - [API Interface](https://iotdb.apache.org/UserGuide/latest/API/Programming-Java-Native-API.html)
-  - Understand IoTDB's Internal Design
-    - [IoTDB Design Documentation](https://cwiki.apache.org/confluence/display/IOTDB/Home)
-  - Finding tasks to be done
-    - [Resolving Issues on Jira](https://issues.apache.org/jira/projects/IOTDB/issues)
+Becoming a Contributor requires no election: anyone who makes a valid contribution to the project is a Contributor. The following is a recommended path to start contributing to IoTDB from scratch.
+
+#### Step 1: Set up your development accounts
+
+- Create a Jira account: <https://issues.apache.org/jira/projects/IOTDB/issues>, used to claim development tasks (issues).
+- Create a Confluence account: <https://cwiki.apache.org/confluence/display/IOTDB/Home>, used to read and write design documents.
+- Once your accounts are ready, send an introduction email to the developer mailing list <dev@iotdb.apache.org> with your **Jira ID** and **Confluence ID**, and the community PMC will grant you the corresponding permissions.
+
+#### Step 2: Get the code running
+
+- To clone the source, build from source, and start and debug IoTDB in an IDE, refer to the documentation in the code repository:
+  - [Apache IoTDB README](https://github.com/apache/iotdb/blob/master/README.md) (environment requirements, building, and starting DataNode/CLI with breakpoint debugging in IDEA)
+  - [Development Guide](https://iotdb.apache.org/Community/Development-Guide.html) (contribution workflow, code formatting, PR conventions, etc.)
+- To get familiar with IoTDB as a user first, see:
+  - [IoTDB download and installation](../UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.md)
+  - [IoTDB Quick Start Guide](https://iotdb.apache.org/UserGuide/latest/QuickStart/QuickStart_apache.html)
+  - [Data Schema and Concepts](https://iotdb.apache.org/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html)
+  - [Java Native API](https://iotdb.apache.org/UserGuide/latest/API/Programming-Java-Native-API.html)
+
+#### Step 3: Understand the internal design
+
+- [IoTDB Design Documentation (Confluence)](https://cwiki.apache.org/confluence/display/IOTDB/Home)
+
+#### Step 4: Pick a task and start contributing
+
+- Browse and claim issues on Jira: <https://issues.apache.org/jira/projects/IOTDB/issues>. Newcomers are encouraged to start with issues labeled newbie / good first issue.
+- For the full contribution workflow (claim an issue → submit a PR → review → merge), see the [Development Guide](https://iotdb.apache.org/Community/Development-Guide.html).
+- If you run into problems, feel free to ask via the mailing list or the channels listed in [Communication Channels](https://iotdb.apache.org/Community/Communication-Channels.html).
 
 ## Code of Conduct in the Apache Community
 

--- a/src/zh/Community/About.md
+++ b/src/zh/Community/About.md
@@ -100,22 +100,34 @@
 
 ### Contributor
 
-- 创建开发平台账号：
-  - 创建 Jira 账号：[https://issues.apache.org/jira/projects/IOTDB/issues](https://issues.apache.org/jira/projects/IOTDB/issues) ，用来认领 issue。
-  - 创建 Confluence 账号：[https://cwiki.apache.org/confluence/display/IOTDB/Home](https://cwiki.apache.org/confluence/display/IOTDB/Home) ，之后用来写设计文档。
-    创建好后，向邮件列表发送一封邮件，包括 **自我介绍** 以及 **Jira ID** 和 **Confluence ID**，社区 PMC 会为账户添加权限。
-- 长期事项：
-  - 学习如何调试 IoTDB
-    - [如何调试 IoTDB server](https://my.oschina.net/u/3664598/blog/4500279)
-  - 学习 IoTDB 的基本使用
-    - [IoTDB 下载与安装](../UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.md)
-    - [IoTDB 快速上手](https://iotdb.apache.org/zh/UserGuide/Master/QuickStart/QuickStart.html)
-    - [数据模式与概念](https://iotdb.apache.org/zh/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html)
-    - [API 接口](https://iotdb.apache.org/zh/UserGuide/latest/API/Programming-Java-Native-API.html)
-  - 了解 IoTDB 的内部设计
-    - [IoTDB 设计文档](https://cwiki.apache.org/confluence/display/IOTDB/Home)
-  - 寻找待做任务
-    - [在 Jira 上解决 issue](https://issues.apache.org/jira/projects/IOTDB/issues)
+成为 Contributor 不需要评选，任何向项目提交了有效贡献的人都是 Contributor。下面是从零开始参与 IoTDB 开发的推荐路径。
+
+#### 第一步：准备开发平台账号
+
+- 注册 Jira 账号：<https://issues.apache.org/jira/projects/IOTDB/issues> ，用于认领开发任务（issue）。
+- 注册 Confluence 账号：<https://cwiki.apache.org/confluence/display/IOTDB/Home> ，用于阅读和编写设计文档。
+- 账号注册完成后，向开发者邮件列表 <dev@iotdb.apache.org> 发送一封自我介绍邮件，附上你的 **Jira ID** 和 **Confluence ID**，社区 PMC 会为你开通相应权限。
+
+#### 第二步：把代码跑起来
+
+- 拉取源码、从源码编译、在 IDE 中启动并调试 IoTDB，请参考代码仓库的说明文档：
+  - [Apache IoTDB README](https://github.com/apache/iotdb/blob/master/README.md)（环境要求、编译，以及在 IDEA 中启动 DataNode/CLI、设置断点调试）
+  - [贡献指南](https://iotdb.apache.org/zh/Community/Development-Guide.html)（贡献流程、代码格式化、PR 规范等）
+- 想先以普通用户身份了解 IoTDB，可参考：
+  - [IoTDB 下载与安装](../UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.md)
+  - [IoTDB 快速上手](https://iotdb.apache.org/zh/UserGuide/latest/QuickStart/QuickStart.html)
+  - [数据模型与概念](https://iotdb.apache.org/zh/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html)
+  - [Java 原生 API](https://iotdb.apache.org/zh/UserGuide/latest/API/Programming-Java-Native-API.html)
+
+#### 第三步：了解内部设计
+
+- [IoTDB 设计文档（Confluence）](https://cwiki.apache.org/confluence/display/IOTDB/Home)
+
+#### 第四步：找一个任务并开始贡献
+
+- 在 Jira 上挑选并认领 issue：<https://issues.apache.org/jira/projects/IOTDB/issues> ，新手建议从标记为新手友好（newbie / good first issue）的任务入手。
+- 完整的贡献流程（认领 issue → 提交 PR → 审阅 → 合并）请见[贡献指南](https://iotdb.apache.org/zh/Community/Development-Guide.html)。
+- 遇到问题，欢迎随时通过[交流与反馈](https://iotdb.apache.org/zh/Community/Feedback.html)中的邮件列表、微信群或 QQ 群提问。
 
 ## 社区公约
 

--- a/src/zh/Community/About.md
+++ b/src/zh/Community/About.md
@@ -102,11 +102,10 @@
 
 成为 Contributor 不需要评选，任何向项目提交了有效贡献的人都是 Contributor。下面是从零开始参与 IoTDB 开发的推荐路径。
 
-#### 第一步：准备开发平台账号
+#### 第一步：加入社区交流
 
-- 注册 Jira 账号：<https://issues.apache.org/jira/projects/IOTDB/issues> ，用于认领开发任务（issue）。
-- 注册 Confluence 账号：<https://cwiki.apache.org/confluence/display/IOTDB/Home> ，用于阅读和编写设计文档。
-- 账号注册完成后，向开发者邮件列表 <dev@iotdb.apache.org> 发送一封自我介绍邮件，附上你的 **Jira ID** 和 **Confluence ID**，社区 PMC 会为你开通相应权限。
+- 订阅开发者邮件列表 <dev@iotdb.apache.org>。邮件列表是 Apache 社区官方指定的交流渠道，开发计划、技术讨论、问题求助都在这里进行，订阅方式见[交流与反馈](https://iotdb.apache.org/zh/Community/Feedback.html)。
+- 第一次参与时，欢迎发一封邮件做个自我介绍。开发过程中遇到任何问题，都可以在邮件列表中发起讨论。
 
 #### 第二步：把代码跑起来
 
@@ -114,19 +113,20 @@
   - [Apache IoTDB README](https://github.com/apache/iotdb/blob/master/README.md)（环境要求、编译，以及在 IDEA 中启动 DataNode/CLI、设置断点调试）
   - [贡献指南](https://iotdb.apache.org/zh/Community/Development-Guide.html)（贡献流程、代码格式化、PR 规范等）
 - 想先以普通用户身份了解 IoTDB，可参考：
-  - [IoTDB 下载与安装](../UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.md)
+  - [IoTDB 下载与安装](https://iotdb.apache.org/zh/UserGuide/latest/Deployment-and-Maintenance/IoTDB-Package_apache.html)
   - [IoTDB 快速上手](https://iotdb.apache.org/zh/UserGuide/latest/QuickStart/QuickStart.html)
   - [数据模型与概念](https://iotdb.apache.org/zh/UserGuide/latest/Basic-Concept/Data-Model-and-Terminology.html)
   - [Java 原生 API](https://iotdb.apache.org/zh/UserGuide/latest/API/Programming-Java-Native-API.html)
 
 #### 第三步：了解内部设计
 
-- [IoTDB 设计文档（Confluence）](https://cwiki.apache.org/confluence/display/IOTDB/Home)
+- IoTDB 的设计与实现主要体现在源码中，建议结合 [README](https://github.com/apache/iotdb/blob/master/README.md) 和源码阅读。
+- 对设计有疑问时，欢迎在邮件列表 <dev@iotdb.apache.org> 中提出，社区成员会参与讨论。
 
 #### 第四步：找一个任务并开始贡献
 
-- 在 Jira 上挑选并认领 issue：<https://issues.apache.org/jira/projects/IOTDB/issues> ，新手建议从标记为新手友好（newbie / good first issue）的任务入手。
-- 完整的贡献流程（认领 issue → 提交 PR → 审阅 → 合并）请见[贡献指南](https://iotdb.apache.org/zh/Community/Development-Guide.html)。
+- 你可以在 [GitHub Issues](https://github.com/apache/iotdb/issues) 或 [Jira](https://issues.apache.org/jira/projects/IOTDB/issues) 上寻找感兴趣的任务，也可以在邮件列表中说明你想做的方向。新手建议从标记为新手友好（newbie / good first issue）的任务入手。
+- 完整的贡献流程（提交 PR → 审阅 → 合并）请见[贡献指南](https://iotdb.apache.org/zh/Community/Development-Guide.html)。
 - 遇到问题，欢迎随时通过[交流与反馈](https://iotdb.apache.org/zh/Community/Feedback.html)中的邮件列表、微信群或 QQ 群提问。
 
 ## 社区公约

--- a/src/zh/Community/Feedback.md
+++ b/src/zh/Community/Feedback.md
@@ -48,10 +48,9 @@ Github Issue 链接：<https://github.com/apache/iotdb/issues>
 ## 途径四：通过微信群、QQ 群等方式进行交流
 
 - 入群方式：
-  - 微信群——添加好友:apache_iotdb
+  - 微信群——添加好友：apache_iotdb
   - QQ 群——659990460
-  - 钉钉群：搜索群名称加入【Apache IoTDB 交流 1 群】
-  - 微信公众号：IoTDB 漫游指南
+  - 微信公众号：Apache IoTDB（微信号：Apache-IoTDB）
   - 我们非常期待您分享您使用 IoTDB 的经验：[调研问卷](https://github.com/apache/iotdb/issues/748)
 
 ## 途径五：通过 Slack 进行交流（全英文）


### PR DESCRIPTION
## Motivation

The Contributor onboarding section of the community page linked to a personal blog post (`my.oschina.net/...`) for "how to debug IoTDB server" that is about 6 years old and no longer matches the current codebase (the old `server/` module has long been refactored into `iotdb-core/datanode`). A community member reported this in discussion #17575 ("the get-started debug doc is 6 years behind").

## Changes

- **`src/Community/About-the-Community.md`** (EN) and **`src/zh/Community/About.md`** (ZH): replace the outdated blog link with the maintained [README](https://github.com/apache/iotdb/blob/master/README.md) (build + IDEA debugging) and the [Development Guide](https://iotdb.apache.org/Community/Development-Guide.html). Restructure the Contributor section into a clear path: set up accounts → get the code running → understand the design → pick a task. Also point the QuickStart link to the stable `latest` path instead of `Master`.
- **`src/zh/Community/Feedback.md`** (ZH): correct the outdated WeChat official account name and remove the discontinued DingTalk group entry.

These are documentation-only changes.

Closes #17575