### PR TITLE
ci: add dependabot config for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` to enable automatic dependency management for the GitHub Actions ecosystem (weekly updates).

## Why

Per the ASF [GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html), all repositories using GitHub Actions must have automatic dependency management in place via GitHub Dependabot (github-actions ecosystem) or Renovate. This repo currently has neither.

This keeps the repo compliant and lets Dependabot track action version updates (e.g. `pnpm/action-setup`, which is pinned to the SHA allowlisted by `apache/infrastructure-actions`).